### PR TITLE
display cleaner name in camera selection

### DIFF
--- a/qml/Application.qml
+++ b/qml/Application.qml
@@ -144,9 +144,9 @@ ApplicationWindow {
             console.log("Window mode changed to: " + applicationSettings.windowMode)
         }
 
-        settingsMenu.comboBoxCamera.onCurrentTextChanged:
+        settingsMenu.comboBoxCamera.onCurrentValueChanged:
         {
-            applicationSettings.cameraName = settingsMenu.comboBoxCamera.currentText
+            applicationSettings.cameraName = settingsMenu.comboBoxCamera.currentValue
         }
 
         settingsMenu.switchEnableSettingsPassword.onCheckedChanged:

--- a/qml/SettingsMenu.qml
+++ b/qml/SettingsMenu.qml
@@ -25,20 +25,20 @@ SettingsMenuForm {
         console.log("Available Camera Count: " + Number(availableCameras.length).toString())
         for(i = 0; i < availableCameras.length; i++)
         {
-            listModel.push(availableCameras[i].description)
+            listModel.push({"text": availableCameras[i].description, "value": availableCameras[i].description})
         }
         var gphotoCameras = gphotoCamera.availableCameras();
         console.log("GPhoto Camera Count: " + Number(gphotoCameras.length).toString())
         for(i = 0; i < gphotoCameras.length; i++)
         {
-            listModel.push(gphotoCameras[i])
+            listModel.push({"text": gphotoCameras[i].text, "value": gphotoCameras[i].value})
         }
         if (form.libcamera) {
             var libcameras = form.libcamera.availableCameras();
             console.log("Libcamera Camera Count: " + Number(libcameras.length).toString())
             for(i = 0; i < libcameras.length; i++)
             {
-                listModel.push(libcameras[i])
+                listModel.push({"text": libcameras[i].text, "value": libcameras[i].value})
             }
         }
         return listModel;

--- a/qml/SettingsMenuForm.ui.qml
+++ b/qml/SettingsMenuForm.ui.qml
@@ -156,6 +156,8 @@ Item {
                         ComboBox {
                             id: comboBoxCamera
                             Layout.preferredWidth: 300
+                            textRole: "text"
+                            valueRole: "value"
                         }
                     }
 

--- a/qml/content/CameraSource.qml
+++ b/qml/content/CameraSource.qml
@@ -31,7 +31,7 @@ Item
       }
       var gphotoCameras = gphotoCamera.availableCameras()
       for (var j = 0; j < gphotoCameras.length; j++) {
-         if (gphotoCameras[j] === cameraName) {
+         if (gphotoCameras[j].value === cameraName) {
             gphotoCamera.cameraName = cameraName
             cameraSource.state = "GPhotoCamera"
             console.log("CameraSource using GPhoto camera device: " + cameraName)
@@ -40,8 +40,8 @@ Item
       }
       if (cameraSource.libcamera) {
          var libcameras = cameraSource.libcamera.availableCameras()
-         for (var j = 0; j < libcameras.length; j++) {
-            if (libcameras[j] === cameraName) {
+         for (var k = 0; k < libcameras.length; k++) {
+            if (libcameras[k].value === cameraName) {
                cameraSource.state = "Libcamera"
                console.log("CameraSource using Libcamera camera device: " + cameraName)
                return

--- a/src/gphotocamera.cpp
+++ b/src/gphotocamera.cpp
@@ -34,18 +34,18 @@ GPhotoCameraDevice::~GPhotoCameraDevice() {
 }
 
 QString GPhotoCameraDevice::getDefautCamera() const {
-  QStringList cameras = availableCameras();
+  QVariantList cameras = availableCameras();
   if (!cameras.isEmpty()) {
-    return cameras.first();
+    return cameras.first().toMap().value("value").toString();
   }
   return QString();
 }
 
-QStringList GPhotoCameraDevice::availableCameras() const {
-  QStringList result;
+QVariantList GPhotoCameraDevice::availableCameras() const {
+  QVariantList result;
   QMetaObject::invokeMethod(mWorker.get(), "availableCameras",
                             Qt::BlockingQueuedConnection,
-                            Q_RETURN_ARG(QStringList, result));
+                            Q_RETURN_ARG(QVariantList, result));
   return result;
 }
 
@@ -269,8 +269,8 @@ void GPhotoCameraWorker::captureImage() {
   emit imageCaptured(image);
 }
 
-QStringList GPhotoCameraWorker::availableCameras() const {
-  QStringList cameraList;
+QVariantList GPhotoCameraWorker::availableCameras() const {
+  QVariantList cameraList;
 
   CameraList *list;
   gp_list_new(&list);
@@ -282,7 +282,11 @@ QStringList GPhotoCameraWorker::availableCameras() const {
     const char *value;
     gp_list_get_name(list, i, &name);
     gp_list_get_value(list, i, &value);
-    cameraList.append(QString("%1 (%2)").arg(name).arg(value));
+
+    QVariantMap entry;
+    entry["text"] = "GPhoto - " + QString::fromUtf8(name);
+    entry["value"] = QString("%1 (%2)").arg(name).arg(value);
+    cameraList.append(entry);
   }
 
   gp_list_free(list);

--- a/src/gphotocamera.h
+++ b/src/gphotocamera.h
@@ -5,6 +5,7 @@
 #include <QImage>
 #include <QTimer>
 #include <QVariant>
+#include <QVariantList>
 #include <memory>
 
 #include <cstdint>
@@ -30,7 +31,7 @@ public:
     GPhotoCameraDevice();
     ~GPhotoCameraDevice() override;
 
-    Q_INVOKABLE QStringList availableCameras() const;
+    Q_INVOKABLE QVariantList availableCameras() const;
 
     Q_INVOKABLE QString getDefautCamera() const;
 
@@ -69,7 +70,7 @@ public slots:
 
     void getPreviewFrame();
     
-    QStringList availableCameras() const;
+    QVariantList availableCameras() const;
 signals:
     void frameReady(const QVideoFrame &frame);
     void errorOccurred(const QString &error);

--- a/src/libcameracamera.cpp
+++ b/src/libcameracamera.cpp
@@ -2,10 +2,12 @@
 #include <QDebug>
 #include <QThread>
 #include <QTimer>
+#include <QVariantMap>
 #include <cerrno>
 #include <cstring>
 #include <libcamera/formats.h>
 #include <libcamera/framebuffer_allocator.h>
+#include <libcamera/property_ids.h>
 #include <qvideoframe.h>
 #include <sys/mman.h>
 #include <opencv2/opencv.hpp>
@@ -43,8 +45,8 @@ LibcameraDevice::~LibcameraDevice() {
   qDebug() << "[INFO] LibcameraDevice destroyed";
 }
 
-QStringList LibcameraDevice::availableCameras() const {
-  QStringList cameras;
+QVariantList LibcameraDevice::availableCameras() const {
+  QVariantList cameras;
   if (mWorker) {
     QMetaObject::invokeMethod(
         mWorker, [this, &cameras]() { cameras = mWorker->availableCameras(); },
@@ -54,8 +56,10 @@ QStringList LibcameraDevice::availableCameras() const {
 }
 
 QString LibcameraDevice::getDefaultCamera() const {
-  QStringList cameras = availableCameras();
-  return cameras.isEmpty() ? QString() : cameras.first();
+  QVariantList cameras = availableCameras();
+  if (cameras.isEmpty())
+    return QString();
+  return cameras.first().toMap().value("value").toString();
 }
 
 void LibcameraDevice::startCamera(const QString &cameraId) {
@@ -118,12 +122,25 @@ void LibCameraWorker::initCameraManager() {
   }
 }
 
-QStringList LibCameraWorker::availableCameras() const {
-  QStringList list;
+QVariantList LibCameraWorker::availableCameras() const {
+  QVariantList list;
   if (!mCameraManager)
     return list;
-  for (auto const &id : mCameraManager->cameras())
-    list << QString::fromStdString(id->id());
+  for (auto const &cam : mCameraManager->cameras()) {
+    QString rawId = QString::fromStdString(cam->id());
+    QString displayName = rawId;
+
+    const auto &props = cam->properties();
+    const auto model = props.get(libcamera::properties::Model);
+    if (model && !model->empty()) {
+      displayName = QString::fromUtf8(model->data(), model->size());
+    }
+
+    QVariantMap entry;
+    entry["text"] = "Libcamera - " + displayName;
+    entry["value"] = rawId;
+    list.append(entry);
+  }
   return list;
 }
 

--- a/src/libcameracamera.h
+++ b/src/libcameracamera.h
@@ -3,6 +3,7 @@
 #include <QObject>
 #include <QStringList>
 #include <QTimer>
+#include <QVariantList>
 #include <QVideoFrameInput>
 #include <memory>
 #include <deque>
@@ -27,7 +28,7 @@ public:
   explicit LibCameraWorker(QObject *parent = nullptr);
   ~LibCameraWorker();
 
-  QStringList availableCameras() const;
+  QVariantList availableCameras() const;
 
 public slots:
   void startCamera(const QString &cameraId);
@@ -79,7 +80,7 @@ public:
   explicit LibcameraDevice(QObject *parent = nullptr);
   ~LibcameraDevice();
 
-  Q_INVOKABLE QStringList availableCameras() const;
+  Q_INVOKABLE QVariantList availableCameras() const;
   Q_INVOKABLE QString getDefaultCamera() const;
 
 public slots:


### PR DESCRIPTION
This pull request standardizes how camera devices are represented and selected throughout the application. It changes the camera lists from simple strings to structured objects with separate `text` (display name) and `value` (unique identifier) fields, ensuring consistency across the UI, QML, and C++ backend. This improves the handling of camera selection and display, especially as more camera types are supported.

**Camera device representation and selection:**

* Changed all camera list representations (for both GPhoto and Libcamera devices) from `QStringList` to `QVariantList` of objects with `text` and `value` fields in both the C++ backend (e.g., `GPhotoCameraDevice::availableCameras`, `LibcameraDevice::availableCameras`) and QML frontend. This enables richer, more consistent camera information in the UI. [[1]](diffhunk://#diff-25be6b13e7a6cc6c413b02835fe6bb2834e08a50222ad96751d90549c3135790L37-R48) [[2]](diffhunk://#diff-25be6b13e7a6cc6c413b02835fe6bb2834e08a50222ad96751d90549c3135790L272-R273) [[3]](diffhunk://#diff-25be6b13e7a6cc6c413b02835fe6bb2834e08a50222ad96751d90549c3135790L285-R289) [[4]](diffhunk://#diff-5e63b3c1518dab0091d8965dcac0a96ffe5082339b55769f916e2b5340d71a55L33-R34) [[5]](diffhunk://#diff-5e63b3c1518dab0091d8965dcac0a96ffe5082339b55769f916e2b5340d71a55L72-R73) [[6]](diffhunk://#diff-5bb61b2a77f97491729bc32077529a5ad9119d518f78681228c6e0184bb2b3c0L46-R49) [[7]](diffhunk://#diff-5bb61b2a77f97491729bc32077529a5ad9119d518f78681228c6e0184bb2b3c0L57-R62) [[8]](diffhunk://#diff-5bb61b2a77f97491729bc32077529a5ad9119d518f78681228c6e0184bb2b3c0L121-R143) [[9]](diffhunk://#diff-041e90d53ff4a68e77dc221b3423575d815e49ad9a5ae451b6c2afcefde4ccd9L30-R31) [[10]](diffhunk://#diff-041e90d53ff4a68e77dc221b3423575d815e49ad9a5ae451b6c2afcefde4ccd9L82-R83)
* Updated the QML camera selection UI (`SettingsMenuForm.ui.qml`, `SettingsMenu.qml`) to use the new `textRole` and `valueRole` properties, and to populate the camera list with objects instead of strings. [[1]](diffhunk://#diff-a6231902c7844af78c6476d2d8f803f7074e4cdc44eb6310df2556309c162e31R159-R160) [[2]](diffhunk://#diff-39f62086274cdb21381d71cdbfa8eda9c84e66fb78093cd7ae672b44680109faL28-R41)
* Modified event handling and logic in QML (`Application.qml`, `CameraSource.qml`) to use the new `currentValue` property for camera selection, and to compare/select cameras by their `value` field rather than by string equality. [[1]](diffhunk://#diff-ac2e2e9a32658613c4e2c1549157076c0da56596ef56f47cdd7af89a6e73739dL147-R149) [[2]](diffhunk://#diff-161375b5589be39190c682680a0801c8e7a22358cecdd135bce9c7212164c2edL34-R34) [[3]](diffhunk://#diff-161375b5589be39190c682680a0801c8e7a22358cecdd135bce9c7212164c2edL43-R44)

**Backend improvements:**

* Enhanced the camera list entries in the backend to include a user-friendly display name (e.g., prefixing with `GPhoto -` or `Libcamera -` and using the camera model name when available) and a unique identifier for each camera. [[1]](diffhunk://#diff-25be6b13e7a6cc6c413b02835fe6bb2834e08a50222ad96751d90549c3135790L285-R289) [[2]](diffhunk://#diff-5bb61b2a77f97491729bc32077529a5ad9119d518f78681228c6e0184bb2b3c0L121-R143)

**Build/compatibility:**

* Added necessary Qt includes for `QVariantList` and `QVariantMap` to support the new camera object representation. [[1]](diffhunk://#diff-5e63b3c1518dab0091d8965dcac0a96ffe5082339b55769f916e2b5340d71a55R8) [[2]](diffhunk://#diff-5bb61b2a77f97491729bc32077529a5ad9119d518f78681228c6e0184bb2b3c0R5-R10) [[3]](diffhunk://#diff-041e90d53ff4a68e77dc221b3423575d815e49ad9a5ae451b6c2afcefde4ccd9R6)