### PR TITLE
feat(gpio): Reimplement GPIO support using libgpiod

### DIFF
--- a/README.md
+++ b/README.md
@@ -367,6 +367,9 @@ In the application, go to **Settings → GPIO** tab:
 5. **LED Brightness Line** — GPIO line offset for the PWM brightness signal.
 6. **PWM Frequency (Hz)** — Software PWM frequency (default: 1000 Hz). Higher values give smoother dimming but increase CPU usage. 500–2000 Hz is typical for LED drivers.
 7. **Invert PWM** — When enabled, inverts the duty cycle (1.0 - brightness). Enable this for active-low LED drivers.
+8. **Enable Camera Wake-up** — When enabled, toggles a GPIO pin before initializing a GPhoto camera (DSLR/mirrorless) to trigger autofocus and wake up the camera hardware. This is useful for cameras that go into sleep after a while.
+9. **Camera Wake-up Line** — GPIO line offset for the camera wake-up autofocus trigger (only visible when camera wake-up is enabled).
+10. **Wake-up Delay (ms)** — Time in milliseconds to hold the autofocus GPIO signal HIGH before returning it to LOW (default: 100 ms). Adjust based on your camera hardware requirements. Typical values are 50–200 ms.
 
 ## Neural Network Background Removal
 

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ Main features are:
 - Printing can also be disabled
 
 **Light/Flash:**
-LED flash can be driven via Raspberry Pi GPIO. Tested configuration:
+LED flash can be driven via GPIO on any supported ARM SBC using **libgpiod**. See [GPIO Configuration](#gpio-configuration) for setup details. Tested configuration:
 - LED Driver: https://www.aliexpress.com/item/14-37-Inch-LED-LCD-Universal-TV-Backlight-Constant-Current-Board-Driver-Boost-Structure-Step-Up/32834942970.html
 - 20W LED: https://www.aliexpress.com/item/1Pcs-High-Power-10W-20W-30W-50W-100W-COB-Integrated-LED-Lamp-Chip-SMD-Bead-DC/32822371892.html
 
@@ -261,6 +261,112 @@ Optional properties:
     </collage>
 </catalog>
 ```
+
+## GPIO Configuration
+
+The photobooth supports controlling LED lighting via GPIO pins using **libgpiod** — the standard Linux GPIO character device interface. This works on any ARM SBC with a `/dev/gpiochip*` device, including Raspberry Pi and Rockchip-based boards.
+
+GPIO is **disabled by default** and must be enabled in **Settings → GPIO**.
+
+### Overview
+
+Two GPIO lines are used:
+
+| Function | Mode | Description |
+|----------|------|-------------|
+| **LED Enable** | Digital Output | Turns the LED driver on/off (HIGH = on, LOW = off) |
+| **LED Brightness** | Software PWM | Controls LED brightness via pulse-width modulation (0–100%) |
+
+The software PWM runs in a dedicated thread for consistent timing, independent of the UI rendering.
+
+### Board Presets & Default Pin Assignments
+
+The settings menu provides board presets that auto-configure the correct GPIO chip and line numbers:
+
+| Board | GPIO Chip | LED Enable Line | LED Brightness Line | Physical Header Pins |
+|-------|-----------|----------------|---------------------|---------------------|
+| **Raspberry Pi 3/4** | `/dev/gpiochip0` | 23 | 18 | Enable: Pin 16 (GPIO23), Brightness: Pin 12 (GPIO18) |
+| **Raspberry Pi 5** | `/dev/gpiochip4` | 23 | 18 | Enable: Pin 16 (GPIO23), Brightness: Pin 12 (GPIO18) |
+| **Orange Pi 3B (RK3566)** | `/dev/gpiochip3` | 13 (GPIO3_B5) | 14 (GPIO3_B6) | Consult board pinout diagram |
+| **Custom** | User-selectable | User-selectable | User-selectable | — |
+
+> **Note:** The Orange Pi 3B default lines (13, 14 on gpiochip3) are examples. Consult your specific board's pinout documentation and adjust in the Settings menu. RK3566 GPIO numbering uses bank notation: e.g. GPIO3_A5 = line offset `3*8+5 = 29` on the corresponding gpiochip. The settings menu enumerates all available lines with their kernel names for easy identification.
+
+### Wiring
+
+```
+        GPIO (Enable Line)          GPIO (Brightness Line / PWM)
+             │                              │
+             ▼                              ▼
+        ┌─────────┐                   ┌──────────┐
+        │ ENABLE   │                   │ PWM/DIM  │
+        │          │                   │          │
+        │  LED     ├───────────────────┤  LED     │
+        │  Driver  │                   │  Driver  │
+        │          │                   │          │
+        └────┬─────┘                   └──────────┘
+             │
+             ▼
+        ┌─────────┐
+        │  LED    │
+        │ (20W)   │
+        └─────────┘
+```
+
+The **Enable** line turns the LED driver on/off. The **Brightness** line controls the duty cycle via software PWM. If your LED driver uses active-low logic (brightness increases as PWM decreases), enable the **"Invert PWM"** toggle in the GPIO settings.
+
+### Permissions / udev Setup
+
+GPIO character devices (`/dev/gpiochip*`) require appropriate permissions. The project ships udev rules and an installer script in the `udev/` directory.
+
+#### Automatic Installation
+
+```bash
+cd udev/
+sudo ./install-gpio-rules.sh
+```
+
+The script will:
+1. Auto-detect your board type from `/proc/device-tree/model`
+2. Install the matching udev rules to `/etc/udev/rules.d/99-gpio-photobooth.rules`
+3. Create a `gpio` group (if it doesn't exist)
+4. Add your user to the `gpio` group
+5. Reload udev rules
+
+**You must log out and back in (or reboot) for the group change to take effect.**
+
+#### Manual Installation
+
+```bash
+# Copy the appropriate rules file
+sudo cp udev/99-gpio-raspberrypi.rules /etc/udev/rules.d/99-gpio-photobooth.rules
+
+# Create gpio group and add your user
+sudo groupadd -f gpio
+sudo usermod -aG gpio $USER
+
+# Reload udev
+sudo udevadm control --reload-rules && sudo udevadm trigger
+
+# Log out and back in, then verify
+ls -la /dev/gpiochip*
+```
+
+#### Flatpak
+
+When running as a Flatpak, the `--device=all` permission grants access to `/dev/gpiochip*` inside the sandbox. You still need the udev rules on the **host** system for correct group permissions.
+
+### Settings Menu
+
+In the application, go to **Settings → GPIO** tab:
+
+1. **Enable GPIO** — Master switch (off by default). All other controls are hidden until enabled.
+2. **Board Preset** — Select your board to auto-fill chip and line defaults. Select "Custom" to manually configure.
+3. **GPIO Chip** — The character device (e.g. `/dev/gpiochip0`). Only editable in "Custom" mode.
+4. **LED Enable Line** — GPIO line offset for the on/off enable signal. Shows all available lines with kernel names.
+5. **LED Brightness Line** — GPIO line offset for the PWM brightness signal.
+6. **PWM Frequency (Hz)** — Software PWM frequency (default: 1000 Hz). Higher values give smoother dimming but increase CPU usage. 500–2000 Hz is typical for LED drivers.
+7. **Invert PWM** — When enabled, inverts the duty cycle (1.0 - brightness). Enable this for active-low LED drivers.
 
 ## Neural Network Background Removal
 

--- a/README.md
+++ b/README.md
@@ -286,7 +286,7 @@ The settings menu provides board presets that auto-configure the correct GPIO ch
 | Board | GPIO Chip | LED Enable Line | LED Brightness Line | Physical Header Pins |
 |-------|-----------|----------------|---------------------|---------------------|
 | **Raspberry Pi 3/4** | `/dev/gpiochip0` | 23 | 18 | Enable: Pin 16 (GPIO23), Brightness: Pin 12 (GPIO18) |
-| **Raspberry Pi 5** | `/dev/gpiochip4` | 23 | 18 | Enable: Pin 16 (GPIO23), Brightness: Pin 12 (GPIO18) |
+| **Raspberry Pi 5** | `/dev/gpiochip0` | 23 | 18 | Enable: Pin 16 (GPIO23), Brightness: Pin 12 (GPIO18) |
 | **Orange Pi 3B (RK3566)** | `/dev/gpiochip3` | 13 (GPIO3_B5) | 14 (GPIO3_B6) | Consult board pinout diagram |
 | **Custom** | User-selectable | User-selectable | User-selectable | — |
 

--- a/README.md
+++ b/README.md
@@ -285,8 +285,7 @@ The settings menu provides board presets that auto-configure the correct GPIO ch
 
 | Board | GPIO Chip | LED Enable Line | LED Brightness Line | Physical Header Pins |
 |-------|-----------|----------------|---------------------|---------------------|
-| **Raspberry Pi 3/4** | `/dev/gpiochip0` | 23 | 18 | Enable: Pin 16 (GPIO23), Brightness: Pin 12 (GPIO18) |
-| **Raspberry Pi 5** | `/dev/gpiochip0` | 23 | 18 | Enable: Pin 16 (GPIO23), Brightness: Pin 12 (GPIO18) |
+| **Raspberry Pi 3/4/5** | `/dev/gpiochip0` | 23 | 18 | Enable: Pin 16 (GPIO23), Brightness: Pin 12 (GPIO18) |
 | **Orange Pi 3B (RK3566)** | `/dev/gpiochip3` | 13 (GPIO3_B5) | 14 (GPIO3_B6) | Consult board pinout diagram |
 | **Custom** | User-selectable | User-selectable | User-selectable | — |
 

--- a/io.github.saeugetier.photobooth.json
+++ b/io.github.saeugetier.photobooth.json
@@ -301,6 +301,22 @@
             ]
         },
         {
+            "name": "libgpiod",
+            "buildsystem": "autotools",
+            "config-opts": [
+                "--enable-tools=no",
+                "--enable-bindings-cxx=no",
+                "--enable-bindings-python=no"
+            ],
+            "sources": [
+                {
+                    "type": "git",
+                    "url": "https://git.kernel.org/pub/scm/libs/libgpiod/libgpiod.git",
+                    "tag": "v2.2.1"
+                }
+            ]
+        },
+        {
             "name": "qtbooth",
             "buildsystem": "qmake",
             "post-install": [

--- a/io.github.saeugetier.photobooth.json
+++ b/io.github.saeugetier.photobooth.json
@@ -4,6 +4,7 @@
     "runtime-version": "6.9",
     "sdk": "org.kde.Sdk",
     "command": "qtbooth",
+    "appstream-compose": false,
     "finish-args": [
         "--share=ipc",
         "--share=network",

--- a/qml/Application.qml
+++ b/qml/Application.qml
@@ -82,6 +82,19 @@ ApplicationWindow {
         collageMenu.printer : printer
         libcamera: libcamera
 
+        // Set up camera wake-up GPIO when settings change
+        onSnapshotMenuChanged: {
+            if (snapshotMenu && snapshotMenu.cameraRenderer) {
+                var cameraDevice = snapshotMenu.cameraRenderer.camera
+                if (cameraDevice && applicationSettings.gpioCameraWakeupEnabled && 
+                    applicationSettings.gpioCameraWakeupLine >= 0) {
+                    // This would require exposing setCameraWakeupGpio from C++
+                    // For now, this is a placeholder for future implementation
+                    console.log("Camera wake-up GPIO configured: line " + applicationSettings.gpioCameraWakeupLine)
+                }
+            }
+        }
+
         settingsMenu.switchPrinter.onCheckedChanged:
         {
             applicationSettings.printEnable = settingsMenu.switchPrinter.checked
@@ -209,6 +222,21 @@ ApplicationWindow {
             applicationSettings.gpioInvertPwm = settingsMenu.switchInvertPwm.checked
         }
 
+        settingsMenu.switchCameraWakeup.onCheckedChanged:
+        {
+            applicationSettings.gpioCameraWakeupEnabled = settingsMenu.switchCameraWakeup.checked
+        }
+
+        settingsMenu.comboBoxCameraWakeupLine.onCurrentValueChanged:
+        {
+            applicationSettings.gpioCameraWakeupLine = Number(settingsMenu.comboBoxCameraWakeupLine.currentValue)
+        }
+
+        settingsMenu.spinBoxCameraWakeupDelay.onValueChanged:
+        {
+            applicationSettings.gpioCameraWakeupDelayMs = settingsMenu.spinBoxCameraWakeupDelay.value
+        }
+
         mainMenu.printerBusy: printer ? printer.busy : false
     }
 
@@ -238,6 +266,9 @@ ApplicationWindow {
         property int gpioLedBrightnessLine: 18
         property int gpioPwmFrequency: 1000
         property bool gpioInvertPwm: true
+        property bool gpioCameraWakeupEnabled: false
+        property int gpioCameraWakeupLine: -1
+        property int gpioCameraWakeupDelayMs: 100
 
         Component.onCompleted:
         {
@@ -257,6 +288,8 @@ ApplicationWindow {
             // GPIO settings
             flow.settingsMenu.switchEnableGpio.checked = gpioEnabled
             flow.settingsMenu.switchInvertPwm.checked = gpioInvertPwm
+            flow.settingsMenu.switchCameraWakeup.checked = gpioCameraWakeupEnabled
+            flow.settingsMenu.spinBoxCameraWakeupDelay.value = gpioCameraWakeupDelayMs
         }
 
         onPrinterNameChanged:

--- a/qml/Application.qml
+++ b/qml/Application.qml
@@ -82,18 +82,7 @@ ApplicationWindow {
         collageMenu.printer : printer
         libcamera: libcamera
 
-        // Set up camera wake-up GPIO when settings change
-        onSnapshotMenuChanged: {
-            if (snapshotMenu && snapshotMenu.cameraRenderer) {
-                var cameraDevice = snapshotMenu.cameraRenderer.camera
-                if (cameraDevice && applicationSettings.gpioCameraWakeupEnabled && 
-                    applicationSettings.gpioCameraWakeupLine >= 0) {
-                    // This would require exposing setCameraWakeupGpio from C++
-                    // For now, this is a placeholder for future implementation
-                    console.log("Camera wake-up GPIO configured: line " + applicationSettings.gpioCameraWakeupLine)
-                }
-            }
-        }
+        // Camera wake-up GPIO is handled in C++ (GPhotoCameraWorker::triggerCameraWakeup)
 
         settingsMenu.switchPrinter.onCheckedChanged:
         {

--- a/qml/Application.qml
+++ b/qml/Application.qml
@@ -174,6 +174,41 @@ ApplicationWindow {
             console.log("Neural network runtime changed to: " + applicationSettings.neuralNetworkRuntime)
         }
 
+        settingsMenu.switchEnableGpio.onCheckedChanged:
+        {
+            applicationSettings.gpioEnabled = settingsMenu.switchEnableGpio.checked
+        }
+
+        settingsMenu.comboBoxGpioChip.onCurrentValueChanged:
+        {
+            applicationSettings.gpioChip = String(settingsMenu.comboBoxGpioChip.currentValue)
+        }
+
+        settingsMenu.comboBoxLedEnableLine.onCurrentValueChanged:
+        {
+            applicationSettings.gpioLedEnableLine = Number(settingsMenu.comboBoxLedEnableLine.currentValue)
+        }
+
+        settingsMenu.comboBoxLedBrightnessLine.onCurrentValueChanged:
+        {
+            applicationSettings.gpioLedBrightnessLine = Number(settingsMenu.comboBoxLedBrightnessLine.currentValue)
+        }
+
+        settingsMenu.spinBoxPwmFrequency.onValueChanged:
+        {
+            applicationSettings.gpioPwmFrequency = settingsMenu.spinBoxPwmFrequency.value
+        }
+
+        settingsMenu.comboBoxBoardPreset.onCurrentValueChanged:
+        {
+            applicationSettings.gpioBoardPreset = String(settingsMenu.comboBoxBoardPreset.currentValue)
+        }
+
+        settingsMenu.switchInvertPwm.onCheckedChanged:
+        {
+            applicationSettings.gpioInvertPwm = settingsMenu.switchInvertPwm.checked
+        }
+
         mainMenu.printerBusy: printer ? printer.busy : false
     }
 
@@ -196,6 +231,13 @@ ApplicationWindow {
         property bool enableSettingsPassword: false
         property int cameraOrientation: 0
         property string neuralNetworkRuntime: "ONNX"
+        property bool gpioEnabled: false
+        property string gpioBoardPreset: "rpi4"
+        property string gpioChip: "/dev/gpiochip0"
+        property int gpioLedEnableLine: 23
+        property int gpioLedBrightnessLine: 18
+        property int gpioPwmFrequency: 1000
+        property bool gpioInvertPwm: true
 
         Component.onCompleted:
         {
@@ -211,6 +253,10 @@ ApplicationWindow {
             flow.collageMenu.multiplePrints = multiplePrints
             flow.snapshotMenu.hideSnapshotSettingsPane = disableSnapshotSettingsPane
             flow.imagePreview.effectButton.visible = !disableEffectPopup
+
+            // GPIO settings
+            flow.settingsMenu.switchEnableGpio.checked = gpioEnabled
+            flow.settingsMenu.switchInvertPwm.checked = gpioInvertPwm
         }
 
         onPrinterNameChanged:

--- a/qml/Application.qml
+++ b/qml/Application.qml
@@ -183,17 +183,32 @@ ApplicationWindow {
 
         settingsMenu.comboBoxGpioChip.onCurrentValueChanged:
         {
-            applicationSettings.gpioChip = String(settingsMenu.comboBoxGpioChip.currentValue)
+            const chipValue = settingsMenu.comboBoxGpioChip.currentValue
+            if (chipValue === undefined || chipValue === null || chipValue === "")
+            {
+                return
+            }
+            applicationSettings.gpioChip = String(chipValue)
         }
 
         settingsMenu.comboBoxLedEnableLine.onCurrentValueChanged:
         {
-            applicationSettings.gpioLedEnableLine = Number(settingsMenu.comboBoxLedEnableLine.currentValue)
+            const lineValue = settingsMenu.comboBoxLedEnableLine.currentValue
+            if (lineValue === undefined || lineValue === null || lineValue === "")
+            {
+                return
+            }
+            applicationSettings.gpioLedEnableLine = Number(lineValue)
         }
 
         settingsMenu.comboBoxLedBrightnessLine.onCurrentValueChanged:
         {
-            applicationSettings.gpioLedBrightnessLine = Number(settingsMenu.comboBoxLedBrightnessLine.currentValue)
+            const lineValue = settingsMenu.comboBoxLedBrightnessLine.currentValue
+            if (lineValue === undefined || lineValue === null || lineValue === "")
+            {
+                return
+            }
+            applicationSettings.gpioLedBrightnessLine = Number(lineValue)
         }
 
         settingsMenu.spinBoxPwmFrequency.onValueChanged:
@@ -218,7 +233,12 @@ ApplicationWindow {
 
         settingsMenu.comboBoxCameraWakeupLine.onCurrentValueChanged:
         {
-            applicationSettings.gpioCameraWakeupLine = Number(settingsMenu.comboBoxCameraWakeupLine.currentValue)
+            const lineValue = settingsMenu.comboBoxCameraWakeupLine.currentValue
+            if (lineValue === undefined || lineValue === null || lineValue === "")
+            {
+                return
+            }
+            applicationSettings.gpioCameraWakeupLine = Number(lineValue)
         }
 
         settingsMenu.spinBoxCameraWakeupDelay.onValueChanged:

--- a/qml/Application.qml
+++ b/qml/Application.qml
@@ -260,7 +260,7 @@ ApplicationWindow {
         property int cameraOrientation: 0
         property string neuralNetworkRuntime: "ONNX"
         property bool gpioEnabled: false
-        property string gpioBoardPreset: "rpi4"
+        property string gpioBoardPreset: "rpi"
         property string gpioChip: "/dev/gpiochip0"
         property int gpioLedEnableLine: 23
         property int gpioLedBrightnessLine: 18

--- a/qml/SettingsMenu.qml
+++ b/qml/SettingsMenu.qml
@@ -113,8 +113,7 @@ SettingsMenuForm {
 
     // Board preset defaults
     readonly property var boardPresets: ({
-        "rpi4":       { chip: "/dev/gpiochip0", enableLine: 23, brightnessLine: 18, pwmFreq: 1000, invertPwm: true },
-        "rpi5":       { chip: "/dev/gpiochip0", enableLine: 23, brightnessLine: 18, pwmFreq: 1000, invertPwm: true },
+        "rpi":        { chip: "/dev/gpiochip0", enableLine: 23, brightnessLine: 18, pwmFreq: 1000, invertPwm: true },
         "orangepi3b": { chip: "/dev/gpiochip3", enableLine: 13, brightnessLine: 14, pwmFreq: 1000, invertPwm: true },
         "custom":     null
     })

--- a/qml/SettingsMenu.qml
+++ b/qml/SettingsMenu.qml
@@ -135,6 +135,11 @@ SettingsMenuForm {
         if (brightnessIdx >= 0)
             comboBoxLedBrightnessLine.currentIndex = brightnessIdx
 
+        // Camera wake-up line
+        var wakeupIdx = comboBoxCameraWakeupLine.indexOfValue(applicationSettings.gpioCameraWakeupLine)
+        if (wakeupIdx >= 0)
+            comboBoxCameraWakeupLine.currentIndex = wakeupIdx
+
         // PWM frequency
         spinBoxPwmFrequency.value = applicationSettings.gpioPwmFrequency
 
@@ -148,6 +153,7 @@ SettingsMenuForm {
         var lines = GPIO.availableLines(chipPath)
         comboBoxLedEnableLine.model = lines
         comboBoxLedBrightnessLine.model = lines
+        comboBoxCameraWakeupLine.model = lines
     }
 
     comboBoxGpioChip.onCurrentValueChanged: {

--- a/qml/SettingsMenu.qml
+++ b/qml/SettingsMenu.qml
@@ -114,7 +114,7 @@ SettingsMenuForm {
     // Board preset defaults
     readonly property var boardPresets: ({
         "rpi4":       { chip: "/dev/gpiochip0", enableLine: 23, brightnessLine: 18, pwmFreq: 1000, invertPwm: true },
-        "rpi5":       { chip: "/dev/gpiochip4", enableLine: 23, brightnessLine: 18, pwmFreq: 1000, invertPwm: true },
+        "rpi5":       { chip: "/dev/gpiochip0", enableLine: 23, brightnessLine: 18, pwmFreq: 1000, invertPwm: true },
         "orangepi3b": { chip: "/dev/gpiochip3", enableLine: 13, brightnessLine: 14, pwmFreq: 1000, invertPwm: true },
         "custom":     null
     })

--- a/qml/SettingsMenu.qml
+++ b/qml/SettingsMenu.qml
@@ -6,6 +6,7 @@ import Qt.labs.platform
 import QtQml
 import GPhotoCamera
 import Libcamera
+import Gpio
 import "content"
 
 SettingsMenuForm {
@@ -100,6 +101,80 @@ SettingsMenuForm {
         // Camera orientation
         var orientIndex = comboBoxCameraOrientation.indexOfValue(applicationSettings.cameraOrientation)
         comboBoxCameraOrientation.currentIndex = orientIndex
+
+        // GPIO settings
+        initGpioControls()
+    }
+
+    // Board preset defaults
+    readonly property var boardPresets: ({
+        "rpi4":       { chip: "/dev/gpiochip0", enableLine: 23, brightnessLine: 18, pwmFreq: 1000, invertPwm: true },
+        "rpi5":       { chip: "/dev/gpiochip4", enableLine: 23, brightnessLine: 18, pwmFreq: 1000, invertPwm: true },
+        "orangepi3b": { chip: "/dev/gpiochip3", enableLine: 13, brightnessLine: 14, pwmFreq: 1000, invertPwm: true },
+        "custom":     null
+    })
+
+    function initGpioControls() {
+        // Populate GPIO chip combo from available hardware
+        var chips = GPIO.availableChips()
+        comboBoxGpioChip.model = chips
+
+        // Set saved chip selection
+        var chipIdx = comboBoxGpioChip.indexOfValue(applicationSettings.gpioChip)
+        if (chipIdx >= 0)
+            comboBoxGpioChip.currentIndex = chipIdx
+
+        // Populate line combos
+        refreshLineComboModels(applicationSettings.gpioChip)
+
+        // Set saved line selections
+        var enableIdx = comboBoxLedEnableLine.indexOfValue(applicationSettings.gpioLedEnableLine)
+        if (enableIdx >= 0)
+            comboBoxLedEnableLine.currentIndex = enableIdx
+        var brightnessIdx = comboBoxLedBrightnessLine.indexOfValue(applicationSettings.gpioLedBrightnessLine)
+        if (brightnessIdx >= 0)
+            comboBoxLedBrightnessLine.currentIndex = brightnessIdx
+
+        // PWM frequency
+        spinBoxPwmFrequency.value = applicationSettings.gpioPwmFrequency
+
+        // Board preset
+        var presetIdx = comboBoxBoardPreset.indexOfValue(applicationSettings.gpioBoardPreset)
+        if (presetIdx >= 0)
+            comboBoxBoardPreset.currentIndex = presetIdx
+    }
+
+    function refreshLineComboModels(chipPath) {
+        var lines = GPIO.availableLines(chipPath)
+        comboBoxLedEnableLine.model = lines
+        comboBoxLedBrightnessLine.model = lines
+    }
+
+    comboBoxGpioChip.onCurrentValueChanged: {
+        if (comboBoxGpioChip.currentValue && comboBoxGpioChip.currentValue !== "")
+            refreshLineComboModels(comboBoxGpioChip.currentValue)
+    }
+
+    comboBoxBoardPreset.onCurrentValueChanged: {
+        var preset = boardPresets[comboBoxBoardPreset.currentValue]
+        if (preset) {
+            // Apply preset values
+            var chipIdx = comboBoxGpioChip.indexOfValue(preset.chip)
+            if (chipIdx >= 0) {
+                comboBoxGpioChip.currentIndex = chipIdx
+            }
+            refreshLineComboModels(preset.chip)
+
+            var enableIdx = comboBoxLedEnableLine.indexOfValue(preset.enableLine)
+            if (enableIdx >= 0)
+                comboBoxLedEnableLine.currentIndex = enableIdx
+            var brightnessIdx = comboBoxLedBrightnessLine.indexOfValue(preset.brightnessLine)
+            if (brightnessIdx >= 0)
+                comboBoxLedBrightnessLine.currentIndex = brightnessIdx
+
+            spinBoxPwmFrequency.value = preset.pwmFreq
+            switchInvertPwm.checked = preset.invertPwm
+        }
     }
 
     function delay(delayTime, cb) {

--- a/qml/SettingsMenu.qml
+++ b/qml/SettingsMenu.qml
@@ -54,6 +54,11 @@ SettingsMenuForm {
         id: mediaDevices
     }
 
+    GPIO {
+        id: gpioHelper
+        enabled: false
+    }
+
     Component.onCompleted:
     {
         versionText = "Version: " + system.getGitHash()
@@ -116,7 +121,7 @@ SettingsMenuForm {
 
     function initGpioControls() {
         // Populate GPIO chip combo from available hardware
-        var chips = GPIO.availableChips()
+        var chips = gpioHelper.availableChips()
         comboBoxGpioChip.model = chips
 
         // Set saved chip selection
@@ -150,7 +155,7 @@ SettingsMenuForm {
     }
 
     function refreshLineComboModels(chipPath) {
-        var lines = GPIO.availableLines(chipPath)
+        var lines = gpioHelper.availableLines(chipPath)
         comboBoxLedEnableLine.model = lines
         comboBoxLedBrightnessLine.model = lines
         comboBoxCameraWakeupLine.model = lines

--- a/qml/SettingsMenu.qml
+++ b/qml/SettingsMenu.qml
@@ -54,8 +54,8 @@ SettingsMenuForm {
         id: mediaDevices
     }
 
-    GPIO {
-        id: gpioHelper
+    Gpiod {
+        id: gpiodHelper
         enabled: false
     }
 
@@ -121,7 +121,7 @@ SettingsMenuForm {
 
     function initGpioControls() {
         // Populate GPIO chip combo from available hardware
-        var chips = gpioHelper.availableChips()
+        var chips = gpiodHelper.availableChips()
         comboBoxGpioChip.model = chips
 
         // Set saved chip selection
@@ -155,7 +155,7 @@ SettingsMenuForm {
     }
 
     function refreshLineComboModels(chipPath) {
-        var lines = gpioHelper.availableLines(chipPath)
+        var lines = gpiodHelper.availableLines(chipPath)
         comboBoxLedEnableLine.model = lines
         comboBoxLedBrightnessLine.model = lines
         comboBoxCameraWakeupLine.model = lines

--- a/qml/SettingsMenuForm.ui.qml
+++ b/qml/SettingsMenuForm.ui.qml
@@ -517,8 +517,7 @@ Item {
                             textRole: "text"
                             valueRole: "value"
                             model: [
-                                {value: "rpi4", text: qsTr("Raspberry Pi 3/4")},
-                                {value: "rpi5", text: qsTr("Raspberry Pi 5")},
+                                {value: "rpi", text: qsTr("Raspberry Pi 3/4/5")},
                                 {value: "orangepi3b", text: qsTr("Orange Pi 3B (RK3566)")},
                                 {value: "custom", text: qsTr("Custom")}
                             ]

--- a/qml/SettingsMenuForm.ui.qml
+++ b/qml/SettingsMenuForm.ui.qml
@@ -30,6 +30,13 @@ Item {
     property alias comboBoxCameraOrientation: comboBoxCameraOrientation
     property alias comboBoxNeuralNetworkRuntime: comboBoxNeuralNetworkRuntime
     property alias buttonSelectPhotoDirectory: buttonSelectPhotoDirectory
+    property alias switchEnableGpio: switchEnableGpio
+    property alias comboBoxBoardPreset: comboBoxBoardPreset
+    property alias comboBoxGpioChip: comboBoxGpioChip
+    property alias comboBoxLedEnableLine: comboBoxLedEnableLine
+    property alias comboBoxLedBrightnessLine: comboBoxLedBrightnessLine
+    property alias spinBoxPwmFrequency: spinBoxPwmFrequency
+    property alias switchInvertPwm: switchInvertPwm
     property var libcamera
 
     ColumnLayout {
@@ -77,6 +84,9 @@ Item {
             }
             TabButton {
                 text: qsTr("System")
+            }
+            TabButton {
+                text: qsTr("GPIO")
             }
         }
 
@@ -458,6 +468,157 @@ Item {
                         Label {
                             text: qsTr("Version: 1.0.0")
                             id: labelVersionText
+                        }
+                    }
+                }
+            }
+
+            // GPIO Tab
+            Item {
+                ColumnLayout {
+                    anchors.horizontalCenter: parent.horizontalCenter
+                    anchors.top: parent.top
+                    anchors.topMargin: 20
+                    spacing: 10
+
+                    RowLayout {
+                        spacing: 10
+                        Label {
+                            text: qsTr("Enable GPIO:")
+                        }
+                        Item {
+                            Layout.fillWidth: true
+                        }
+                        Switch {
+                            id: switchEnableGpio
+                        }
+                    }
+
+                    ToolSeparator {
+                        orientation: Qt.Horizontal
+                        Layout.fillWidth: true
+                    }
+
+                    RowLayout {
+                        visible: switchEnableGpio.checked
+                        spacing: 10
+                        Label {
+                            text: qsTr("Board Preset:")
+                        }
+                        Item {
+                            Layout.fillWidth: true
+                        }
+                        ComboBox {
+                            id: comboBoxBoardPreset
+                            Layout.preferredWidth: 300
+                            textRole: "text"
+                            valueRole: "value"
+                            model: [
+                                {value: "rpi4", text: qsTr("Raspberry Pi 3/4")},
+                                {value: "rpi5", text: qsTr("Raspberry Pi 5")},
+                                {value: "orangepi3b", text: qsTr("Orange Pi 3B (RK3566)")},
+                                {value: "custom", text: qsTr("Custom")}
+                            ]
+                        }
+                    }
+
+                    ToolSeparator {
+                        visible: switchEnableGpio.checked
+                        orientation: Qt.Horizontal
+                        Layout.fillWidth: true
+                    }
+
+                    RowLayout {
+                        visible: switchEnableGpio.checked
+                        spacing: 10
+                        Label {
+                            text: qsTr("GPIO Chip:")
+                        }
+                        Item {
+                            Layout.fillWidth: true
+                        }
+                        ComboBox {
+                            id: comboBoxGpioChip
+                            Layout.preferredWidth: 300
+                            textRole: "text"
+                            valueRole: "value"
+                            enabled: comboBoxBoardPreset.currentValue === "custom"
+                        }
+                    }
+
+                    RowLayout {
+                        visible: switchEnableGpio.checked
+                        spacing: 10
+                        Label {
+                            text: qsTr("LED Enable Line:")
+                        }
+                        Item {
+                            Layout.fillWidth: true
+                        }
+                        ComboBox {
+                            id: comboBoxLedEnableLine
+                            Layout.preferredWidth: 300
+                            textRole: "text"
+                            valueRole: "value"
+                            enabled: comboBoxBoardPreset.currentValue === "custom"
+                        }
+                    }
+
+                    RowLayout {
+                        visible: switchEnableGpio.checked
+                        spacing: 10
+                        Label {
+                            text: qsTr("LED Brightness Line:")
+                        }
+                        Item {
+                            Layout.fillWidth: true
+                        }
+                        ComboBox {
+                            id: comboBoxLedBrightnessLine
+                            Layout.preferredWidth: 300
+                            textRole: "text"
+                            valueRole: "value"
+                            enabled: comboBoxBoardPreset.currentValue === "custom"
+                        }
+                    }
+
+                    ToolSeparator {
+                        visible: switchEnableGpio.checked
+                        orientation: Qt.Horizontal
+                        Layout.fillWidth: true
+                    }
+
+                    RowLayout {
+                        visible: switchEnableGpio.checked
+                        spacing: 10
+                        Label {
+                            text: qsTr("PWM Frequency (Hz):")
+                        }
+                        Item {
+                            Layout.fillWidth: true
+                        }
+                        SpinBox {
+                            id: spinBoxPwmFrequency
+                            from: 100
+                            to: 10000
+                            stepSize: 100
+                            value: 1000
+                            editable: true
+                            enabled: comboBoxBoardPreset.currentValue === "custom"
+                        }
+                    }
+
+                    RowLayout {
+                        visible: switchEnableGpio.checked
+                        spacing: 10
+                        Label {
+                            text: qsTr("Invert PWM:")
+                        }
+                        Item {
+                            Layout.fillWidth: true
+                        }
+                        Switch {
+                            id: switchInvertPwm
                         }
                     }
                 }

--- a/qml/SettingsMenuForm.ui.qml
+++ b/qml/SettingsMenuForm.ui.qml
@@ -37,6 +37,9 @@ Item {
     property alias comboBoxLedBrightnessLine: comboBoxLedBrightnessLine
     property alias spinBoxPwmFrequency: spinBoxPwmFrequency
     property alias switchInvertPwm: switchInvertPwm
+    property alias switchCameraWakeup: switchCameraWakeup
+    property alias comboBoxCameraWakeupLine: comboBoxCameraWakeupLine
+    property alias spinBoxCameraWakeupDelay: spinBoxCameraWakeupDelay
     property var libcamera
 
     ColumnLayout {
@@ -619,6 +622,62 @@ Item {
                         }
                         Switch {
                             id: switchInvertPwm
+                        }
+                    }
+
+                    ToolSeparator {
+                        visible: switchEnableGpio.checked
+                        orientation: Qt.Horizontal
+                        Layout.fillWidth: true
+                    }
+
+                    RowLayout {
+                        visible: switchEnableGpio.checked
+                        spacing: 10
+                        Label {
+                            text: qsTr("Enable Camera Wake-up:")
+                        }
+                        Item {
+                            Layout.fillWidth: true
+                        }
+                        Switch {
+                            id: switchCameraWakeup
+                        }
+                    }
+
+                    RowLayout {
+                        visible: switchEnableGpio.checked && switchCameraWakeup.checked
+                        spacing: 10
+                        Label {
+                            text: qsTr("Camera Wake-up Line:")
+                        }
+                        Item {
+                            Layout.fillWidth: true
+                        }
+                        ComboBox {
+                            id: comboBoxCameraWakeupLine
+                            Layout.preferredWidth: 300
+                            textRole: "text"
+                            valueRole: "value"
+                        }
+                    }
+
+                    RowLayout {
+                        visible: switchEnableGpio.checked && switchCameraWakeup.checked
+                        spacing: 10
+                        Label {
+                            text: qsTr("Wake-up Delay (ms):")
+                        }
+                        Item {
+                            Layout.fillWidth: true
+                        }
+                        SpinBox {
+                            id: spinBoxCameraWakeupDelay
+                            from: 0
+                            to: 5000
+                            stepSize: 10
+                            value: 100
+                            editable: true
                         }
                     }
                 }

--- a/qml/SnapshotMenu.qml
+++ b/qml/SnapshotMenu.qml
@@ -1,5 +1,5 @@
 import QtQuick
-import GPIO
+import Gpio
 
 SnapshotMenuForm {
     id: form
@@ -33,7 +33,10 @@ SnapshotMenuForm {
     GPIO
     {
         id: ledEnablePin
-        pin:  23
+        chipPath: applicationSettings.gpioChip
+        line: applicationSettings.gpioLedEnableLine
+        mode: GPIO.Output
+        enabled: applicationSettings.gpioEnabled
         value: 0.0
     }
 
@@ -77,25 +80,29 @@ SnapshotMenuForm {
     GPIO
     {
         id: ledBrightnessPin
-        pin:  18
-        value: 1.0 - snapshotSettings.viewFinderBrightness
+        chipPath: applicationSettings.gpioChip
+        line: applicationSettings.gpioLedBrightnessLine
+        mode: GPIO.PWM
+        pwmFrequency: applicationSettings.gpioPwmFrequency
+        enabled: applicationSettings.gpioEnabled
+        value: applicationSettings.gpioInvertPwm ? (1.0 - snapshotSettings.viewFinderBrightness) : snapshotSettings.viewFinderBrightness
     }
 
     cameraRenderer.onStateChanged:
     {
         if(cameraRenderer.state === "snapshot" && snapshotSettings.flashEnabled)
         {
-            ledBrightnessPin.value = 1.0 - snapshotSettings.flashBrightness
+            ledBrightnessPin.value = applicationSettings.gpioInvertPwm ? (1.0 - snapshotSettings.flashBrightness) : snapshotSettings.flashBrightness
         }
         else
         {
-            ledBrightnessPin.value = 1.0 - snapshotSettings.viewFinderBrightness
+            ledBrightnessPin.value = applicationSettings.gpioInvertPwm ? (1.0 - snapshotSettings.viewFinderBrightness) : snapshotSettings.viewFinderBrightness
         }
     }
 
     snapshotSettings.onViewFinderBrightnessChanged:
     {
-        ledBrightnessPin.value = 1.0 - snapshotSettings.viewFinderBrightness
+        ledBrightnessPin.value = applicationSettings.gpioInvertPwm ? (1.0 - snapshotSettings.viewFinderBrightness) : snapshotSettings.viewFinderBrightness
     }
 
     shutterButton.onTriggerSnapshot:

--- a/qml/SnapshotMenu.qml
+++ b/qml/SnapshotMenu.qml
@@ -30,12 +30,12 @@ SnapshotMenuForm {
 
     cameraRenderer.mirrored: applicationSettings.cameraMirrored
 
-    GPIO
+    Gpiod
     {
         id: ledEnablePin
         chipPath: applicationSettings.gpioChip
         line: applicationSettings.gpioLedEnableLine
-        mode: GPIO.Output
+        mode: Gpiod.Output
         enabled: applicationSettings.gpioEnabled
         value: 0.0
     }
@@ -77,12 +77,12 @@ SnapshotMenuForm {
         }
     }
 
-    GPIO
+    Gpiod
     {
         id: ledBrightnessPin
         chipPath: applicationSettings.gpioChip
         line: applicationSettings.gpioLedBrightnessLine
-        mode: GPIO.PWM
+        mode: Gpiod.PWM
         pwmFrequency: applicationSettings.gpioPwmFrequency
         enabled: applicationSettings.gpioEnabled
         value: applicationSettings.gpioInvertPwm ? (1.0 - snapshotSettings.viewFinderBrightness) : snapshotSettings.viewFinderBrightness

--- a/qtbooth.pro
+++ b/qtbooth.pro
@@ -4,7 +4,7 @@ CONFIG += c++17 qml_debug
 
 !contains(QT_CONFIG, no-pkg-config) {
     CONFIG += link_pkgconfig
-    PKGCONFIG += opencv4 libcamera
+    PKGCONFIG += opencv4 libcamera libgpiod
 } else {
     LIBS += -lopencv_core -lopencv_imgproc -lopencv_imgcodecs -lcamera -lcamera-base -lcamera-controls
 }

--- a/qtbooth.pro
+++ b/qtbooth.pro
@@ -6,7 +6,7 @@ CONFIG += c++17 qml_debug
     CONFIG += link_pkgconfig
     PKGCONFIG += opencv4 libcamera libgpiod
 } else {
-    LIBS += -lopencv_core -lopencv_imgproc -lopencv_imgcodecs -lcamera -lcamera-base -lcamera-controls
+    LIBS += -lopencv_core -lopencv_imgproc -lopencv_imgcodecs -lcamera -lcamera-base -lcamera-controls -lgpiod
 }
 
 SOURCES += src/collageiconmodel.cpp \

--- a/src/gphotocamera.cpp
+++ b/src/gphotocamera.cpp
@@ -2,7 +2,6 @@
 #include <QDebug>
 #include <QString>
 #include <QVideoFrame>
-#include <QCoreApplication>
 #include <QSettings>
 #include <gphoto2/gphoto2-camera.h>
 #include <gphoto2/gphoto2-context.h>

--- a/src/gphotocamera.cpp
+++ b/src/gphotocamera.cpp
@@ -96,20 +96,19 @@ GPhotoCameraWorker::GPhotoCameraWorker()
 GPhotoCameraWorker::~GPhotoCameraWorker() {}
 
 void GPhotoCameraWorker::triggerCameraWakeup() {
-  // Read GPIO settings from QSettings
+  // Read GPIO settings from QSettings (stored by QML Settings { category: "Application" })
   QSettings settings;
-  
-  bool gpioEnabled = settings.value("gpioEnabled", false).toBool();
-  bool cameraWakeupEnabled = settings.value("gpioCameraWakeupEnabled", false).toBool();
-  
+
+  bool gpioEnabled = settings.value("Application/gpioEnabled", false).toBool();
+  bool cameraWakeupEnabled = settings.value("Application/gpioCameraWakeupEnabled", false).toBool();
+
   if (!gpioEnabled || !cameraWakeupEnabled) {
     return;
   }
-  
-  QString gpioChip = settings.value("gpioChip", "/dev/gpiochip0").toString();
-  int wakeupLine = settings.value("gpioCameraWakeupLine", 17).toInt();
-  int delayMs = settings.value("gpioCameraWakeupDelayMs", 100).toInt();
-  
+
+  QString gpioChip = settings.value("Application/gpioChip", "/dev/gpiochip0").toString();
+  int wakeupLine = settings.value("Application/gpioCameraWakeupLine", 17).toInt();
+  int delayMs = settings.value("Application/gpioCameraWakeupDelayMs", 100).toInt();
   qDebug() << "Triggering camera wake-up GPIO on" << gpioChip << "line" << wakeupLine;
   
   try {

--- a/src/gphotocamera.cpp
+++ b/src/gphotocamera.cpp
@@ -16,6 +16,8 @@ constexpr auto capturingFailLimit = 10;
 
 GPhotoCameraDevice::GPhotoCameraDevice() : mWorker(new GPhotoCameraWorker()) {
   mWorker->moveToThread(&mWorkerThread);
+  connect(&mWorkerThread, &QThread::started, mWorker.get(),
+          &GPhotoCameraWorker::triggerCameraWakeup, Qt::QueuedConnection);
 
   connect(this, &QVideoFrameInput::readyToSendVideoFrame, mWorker.get(),
           &GPhotoCameraWorker::getPreviewFrame);
@@ -88,9 +90,6 @@ GPhotoCameraWorker::GPhotoCameraWorker()
 
   mKeepAliveTimer.setInterval(1000 * 60); // Check every minute
   mKeepAliveTimer.setSingleShot(true);
-  
-  // Trigger camera wake-up GPIO on startup before camera enumeration
-  triggerCameraWakeup();
 }
 GPhotoCameraWorker::~GPhotoCameraWorker() {}
 

--- a/src/gphotocamera.cpp
+++ b/src/gphotocamera.cpp
@@ -140,9 +140,30 @@ void GPhotoCameraWorker::triggerCameraWakeup() {
 }
 
 void GPhotoCameraWorker::startCamera(const QString &cameraName) {
-  // Trigger camera wake-up GPIO before starting camera
-  triggerCameraWakeup();
-  
+  auto isCameraAvailable = [this](const QString &fullName) {
+    if (fullName.isEmpty()) {
+      return false;
+    }
+    const auto cameras = availableCameras();
+    for (const auto &entryVar : cameras) {
+      const auto entry = entryVar.toMap();
+      if (entry.value("value").toString() == fullName) {
+        return true;
+      }
+    }
+    return false;
+  };
+
+  // camera may be in stand by. If not found, trigger wake-up and try again after a short delay
+  if (!isCameraAvailable(cameraName)) {
+    triggerCameraWakeup();
+    std::this_thread::sleep_for(std::chrono::milliseconds(200));
+    if (!isCameraAvailable(cameraName)) {
+      emit errorOccurred(tr("Camera %1 not found").arg(cameraName));
+      return;
+    }
+  }
+
   if (mCameraStarted) {
     stopCamera();
   }

--- a/src/gphotocamera.cpp
+++ b/src/gphotocamera.cpp
@@ -2,10 +2,14 @@
 #include <QDebug>
 #include <QString>
 #include <QVideoFrame>
+#include <QCoreApplication>
+#include <QSettings>
 #include <gphoto2/gphoto2-camera.h>
 #include <gphoto2/gphoto2-context.h>
 #include <gphoto2/gphoto2-list.h>
 #include <gphoto2/gphoto2-port.h>
+#include <thread>
+#include <chrono>
 
 namespace {
 constexpr auto capturingFailLimit = 10;
@@ -85,10 +89,60 @@ GPhotoCameraWorker::GPhotoCameraWorker()
 
   mKeepAliveTimer.setInterval(1000 * 60); // Check every minute
   mKeepAliveTimer.setSingleShot(true);
+  
+  // Trigger camera wake-up GPIO on startup before camera enumeration
+  triggerCameraWakeup();
 }
 GPhotoCameraWorker::~GPhotoCameraWorker() {}
 
+void GPhotoCameraWorker::triggerCameraWakeup() {
+  // Read GPIO settings from QSettings
+  QSettings settings;
+  
+  bool gpioEnabled = settings.value("gpioEnabled", false).toBool();
+  bool cameraWakeupEnabled = settings.value("gpioCameraWakeupEnabled", false).toBool();
+  
+  if (!gpioEnabled || !cameraWakeupEnabled) {
+    return;
+  }
+  
+  QString gpioChip = settings.value("gpioChip", "/dev/gpiochip0").toString();
+  int wakeupLine = settings.value("gpioCameraWakeupLine", 17).toInt();
+  int delayMs = settings.value("gpioCameraWakeupDelayMs", 100).toInt();
+  
+  qDebug() << "Triggering camera wake-up GPIO on" << gpioChip << "line" << wakeupLine;
+  
+  try {
+    // Create GPIO instance for wake-up
+    mCameraWakeupGpio = std::make_unique<GPIO>();
+    mCameraWakeupGpio->setChipPath(gpioChip);
+    mCameraWakeupGpio->setLine(wakeupLine);
+    mCameraWakeupGpio->setMode(GPIO::Output);
+    mCameraWakeupGpio->setEnabled(true);
+    
+    // Trigger GPIO (set high)
+    mCameraWakeupGpio->setValue(1.0);
+    
+    // Wait for delay
+    if (delayMs > 0) {
+      std::this_thread::sleep_for(std::chrono::milliseconds(delayMs));
+    }
+    
+    // Release GPIO (set low)
+    mCameraWakeupGpio->setValue(0.0);
+    mCameraWakeupGpio->setEnabled(false);
+    mCameraWakeupGpio.reset();
+    
+    qDebug() << "Camera wake-up GPIO trigger completed";
+  } catch (const std::exception &e) {
+    qWarning() << "Failed to trigger camera wake-up GPIO:" << e.what();
+  }
+}
+
 void GPhotoCameraWorker::startCamera(const QString &cameraName) {
+  // Trigger camera wake-up GPIO before starting camera
+  triggerCameraWakeup();
+  
   if (mCameraStarted) {
     stopCamera();
   }

--- a/src/gphotocamera.cpp
+++ b/src/gphotocamera.cpp
@@ -114,10 +114,10 @@ void GPhotoCameraWorker::triggerCameraWakeup() {
   
   try {
     // Create GPIO instance for wake-up
-    mCameraWakeupGpio = std::make_unique<GPIO>();
+    mCameraWakeupGpio = std::make_unique<Gpiod>();
     mCameraWakeupGpio->setChipPath(gpioChip);
     mCameraWakeupGpio->setLine(wakeupLine);
-    mCameraWakeupGpio->setMode(GPIO::Output);
+    mCameraWakeupGpio->setMode(Gpiod::Output);
     mCameraWakeupGpio->setEnabled(true);
     
     // Trigger GPIO (set high)

--- a/src/gphotocamera.cpp
+++ b/src/gphotocamera.cpp
@@ -106,10 +106,13 @@ void GPhotoCameraWorker::triggerCameraWakeup() {
   }
 
   QString gpioChip = settings.value("Application/gpioChip", "/dev/gpiochip0").toString();
-  int wakeupLine = settings.value("Application/gpioCameraWakeupLine", 17).toInt();
+  int wakeupLine = settings.value("Application/gpioCameraWakeupLine", -1).toInt();
   int delayMs = settings.value("Application/gpioCameraWakeupDelayMs", 100).toInt();
+  if (wakeupLine < 0) {
+    qWarning() << "Camera wake-up GPIO is enabled but no valid GPIO line is configured";
+    return;
+  }
   qDebug() << "Triggering camera wake-up GPIO on" << gpioChip << "line" << wakeupLine;
-  
   try {
     // Create GPIO instance for wake-up
     mCameraWakeupGpio = std::make_unique<Gpiod>();

--- a/src/gphotocamera.h
+++ b/src/gphotocamera.h
@@ -71,6 +71,7 @@ public slots:
     void captureImage();
 
     void getPreviewFrame();
+    void triggerCameraWakeup();
     
     QVariantList availableCameras() const;
 signals:
@@ -94,10 +95,8 @@ protected:
     void waitForOperationCompleted();
     QVariant parameter(const QString &name);
     bool setParameter(const QString &name, const QVariant &value);
-    void triggerCameraWakeup();
 protected slots:
     // check and set capture parameters to keep camera alive
     void checkCaptureParameter();
 };
-
 

--- a/src/gphotocamera.h
+++ b/src/gphotocamera.h
@@ -89,7 +89,7 @@ protected:
     uint32_t mCapturingFailCount = 0;
     
     // GPIO wake-up members
-    std::unique_ptr<GPIO> mCameraWakeupGpio;
+    std::unique_ptr<Gpiod> mCameraWakeupGpio;
 
     void waitForOperationCompleted();
     QVariant parameter(const QString &name);

--- a/src/gphotocamera.h
+++ b/src/gphotocamera.h
@@ -14,6 +14,8 @@
 #include <gphoto2/gphoto2-port.h>
 #include <gphoto2/gphoto2-camera.h>
 
+#include "gpio.h"
+
 
 class GPhotoCameraWorker;
 
@@ -85,10 +87,14 @@ protected:
     CameraFilePtr mPreviewFile;
     bool mCameraStarted = false;
     uint32_t mCapturingFailCount = 0;
+    
+    // GPIO wake-up members
+    std::unique_ptr<GPIO> mCameraWakeupGpio;
 
     void waitForOperationCompleted();
     QVariant parameter(const QString &name);
     bool setParameter(const QString &name, const QVariant &value);
+    void triggerCameraWakeup();
 protected slots:
     // check and set capture parameters to keep camera alive
     void checkCaptureParameter();

--- a/src/gpio.cpp
+++ b/src/gpio.cpp
@@ -360,7 +360,8 @@ void Gpiod::pwmWorker()
         duty = std::clamp(duty, 0.001f, 0.999f);
 
         // Calculate period in nanoseconds
-        long periodNs = 1000000000L / m_pwmFrequency;
+        const int frequency = m_pwmFrequency.load(std::memory_order_relaxed);
+        long periodNs = 1000000000L / frequency;
         long onTimeNs = static_cast<long>(periodNs * duty);
         long offTimeNs = periodNs - onTimeNs;
 

--- a/src/gpio.cpp
+++ b/src/gpio.cpp
@@ -9,23 +9,23 @@
 #include <cerrno>
 #include <cstring>
 
-GPIO::GPIO(QObject *parent)
+Gpiod::Gpiod(QObject *parent)
     : QObject(parent)
 {
 }
 
-GPIO::~GPIO()
+Gpiod::~Gpiod()
 {
     stopPwmThread();
     closeLine();
 }
 
-QString GPIO::chipPath() const
+QString Gpiod::chipPath() const
 {
     return m_chipPath;
 }
 
-void GPIO::setChipPath(const QString &chipPath)
+void Gpiod::setChipPath(const QString &chipPath)
 {
     if (m_chipPath != chipPath) {
         closeLine();
@@ -36,12 +36,12 @@ void GPIO::setChipPath(const QString &chipPath)
     }
 }
 
-int GPIO::line() const
+int Gpiod::line() const
 {
     return m_line;
 }
 
-void GPIO::setLine(int line)
+void Gpiod::setLine(int line)
 {
     if (m_line != line) {
         closeLine();
@@ -52,12 +52,12 @@ void GPIO::setLine(int line)
     }
 }
 
-float GPIO::value() const
+float Gpiod::value() const
 {
     return m_value;
 }
 
-void GPIO::setValue(float value)
+void Gpiod::setValue(float value)
 {
     float clamped = std::clamp(value, 0.0f, 1.0f);
     if (std::fabs(clamped - m_value) > 0.005f || (clamped == 0.0f) != (m_value == 0.0f) || (clamped == 1.0f) != (m_value == 1.0f)) {
@@ -67,12 +67,12 @@ void GPIO::setValue(float value)
     }
 }
 
-GPIO::Mode GPIO::mode() const
+Gpiod::Mode Gpiod::mode() const
 {
     return m_mode;
 }
 
-void GPIO::setMode(Mode mode)
+void Gpiod::setMode(Mode mode)
 {
     if (m_mode != mode) {
         stopPwmThread();
@@ -82,12 +82,12 @@ void GPIO::setMode(Mode mode)
     }
 }
 
-int GPIO::pwmFrequency() const
+int Gpiod::pwmFrequency() const
 {
     return m_pwmFrequency;
 }
 
-void GPIO::setPwmFrequency(int frequency)
+void Gpiod::setPwmFrequency(int frequency)
 {
     if (frequency < 1)
         frequency = 1;
@@ -97,12 +97,12 @@ void GPIO::setPwmFrequency(int frequency)
     }
 }
 
-bool GPIO::enabled() const
+bool Gpiod::enabled() const
 {
     return m_enabled;
 }
 
-void GPIO::setEnabled(bool enabled)
+void Gpiod::setEnabled(bool enabled)
 {
     if (m_enabled != enabled) {
         m_enabled = enabled;
@@ -117,7 +117,7 @@ void GPIO::setEnabled(bool enabled)
     }
 }
 
-QVariantList GPIO::availableChips()
+QVariantList Gpiod::availableChips()
 {
     QVariantList chips;
     QDir devDir("/dev");
@@ -202,7 +202,7 @@ QVariantList GPIO::availableChips()
     return chips;
 }
 
-QVariantList GPIO::availableLines(const QString &chipPath)
+QVariantList Gpiod::availableLines(const QString &chipPath)
 {
     QVariantList lines;
 
@@ -246,7 +246,7 @@ QVariantList GPIO::availableLines(const QString &chipPath)
     return lines;
 }
 
-void GPIO::openLine()
+void Gpiod::openLine()
 {
     closeLine();
 
@@ -286,7 +286,7 @@ void GPIO::openLine()
     qDebug() << "GPIO: Opened line" << m_line << "on" << m_chipPath;
 }
 
-void GPIO::closeLine()
+void Gpiod::closeLine()
 {
     stopPwmThread();
 
@@ -301,7 +301,7 @@ void GPIO::closeLine()
     }
 }
 
-void GPIO::applyValue()
+void Gpiod::applyValue()
 {
     if (!m_enabled || !m_request)
         return;
@@ -329,17 +329,17 @@ void GPIO::applyValue()
     }
 }
 
-void GPIO::startPwmThread()
+void Gpiod::startPwmThread()
 {
     if (m_pwmRunning.load(std::memory_order_acquire))
         return;
 
     m_pwmRunning.store(true, std::memory_order_release);
-    m_pwmThread = std::thread(&GPIO::pwmWorker, this);
+    m_pwmThread = std::thread(&Gpiod::pwmWorker, this);
     qDebug() << "GPIO: PWM thread started for line" << m_line << "at" << m_pwmFrequency << "Hz";
 }
 
-void GPIO::stopPwmThread()
+void Gpiod::stopPwmThread()
 {
     if (m_pwmRunning.load(std::memory_order_acquire)) {
         m_pwmRunning.store(false, std::memory_order_release);
@@ -348,7 +348,7 @@ void GPIO::stopPwmThread()
     }
 }
 
-void GPIO::pwmWorker()
+void Gpiod::pwmWorker()
 {
     const unsigned int lineOffset = static_cast<unsigned int>(m_line);
 

--- a/src/gpio.cpp
+++ b/src/gpio.cpp
@@ -8,6 +8,7 @@
 #include <chrono>
 #include <cerrno>
 #include <cstring>
+#include <time.h>
 
 Gpiod::Gpiod(QObject *parent)
     : QObject(parent)

--- a/src/gpio.cpp
+++ b/src/gpio.cpp
@@ -1,92 +1,342 @@
 #include "gpio.h"
-#include <QFile>
-#include <cmath>
 #include <QDebug>
-#include "assert.h"
+#include <QDir>
+#include <QVariantMap>
+#include <cmath>
+#include <algorithm>
+#include <chrono>
 
-#define IO_DEVICE "/dev/pi-blaster"
-
-bool cmpf(float A, float B, float epsilon = 0.005f)
+GPIO::GPIO(QObject *parent)
+    : QObject(parent)
 {
-    return (fabs(A - B) < epsilon);
-}
-
-template<class T>
-constexpr const T& clamp( const T& v, const T& lo, const T& hi )
-{
-    assert( !(hi < lo) );
-    return (v < lo) ? lo : (hi < v) ? hi : v;
-}
-
-GPIO::GPIO(QObject *parent) : QObject(parent), pinValue(0.0f)
-{
-
 }
 
 GPIO::~GPIO()
 {
-    if(pinNumber >= 0)
-    {
-        QFile io(IO_DEVICE);
-        if(io.open(QFile::WriteOnly | QIODevice::Text))
-        {
-            QString io_string = QString("release ") + QString::number(pinNumber) + "\n";
-            io.write(io_string.toLatin1());
-            io.flush();
-            io.close();
-        }
+    stopPwmThread();
+    closeLine();
+}
+
+QString GPIO::chipPath() const
+{
+    return m_chipPath;
+}
+
+void GPIO::setChipPath(const QString &chipPath)
+{
+    if (m_chipPath != chipPath) {
+        closeLine();
+        m_chipPath = chipPath;
+        emit chipPathChanged(m_chipPath);
+        if (m_enabled && m_line >= 0)
+            openLine();
     }
 }
 
-int GPIO::pin() const
+int GPIO::line() const
 {
-    return pinNumber;
+    return m_line;
 }
 
-void GPIO::setPin(int pin)
+void GPIO::setLine(int line)
 {
-    if(pin >= 0 && pin <= 26)
-    {
-        if(pin != pinNumber)
-        {
-            pinNumber = pin;
-            emit pinChanged(pin);
-        }
-
-        qDebug() << "Allocated pin: " << pinNumber;
+    if (m_line != line) {
+        closeLine();
+        m_line = line;
+        emit lineChanged(m_line);
+        if (m_enabled && m_line >= 0)
+            openLine();
     }
 }
 
 float GPIO::value() const
 {
-    return pinValue;
+    return m_value;
 }
 
 void GPIO::setValue(float value)
 {
-    float _value = clamp<float>(value, 0.0, 1.0);
+    float clamped = std::clamp(value, 0.0f, 1.0f);
+    if (std::fabs(clamped - m_value) > 0.005f || (clamped == 0.0f) != (m_value == 0.0f) || (clamped == 1.0f) != (m_value == 1.0f)) {
+        m_value = clamped;
+        emit valueChanged(m_value);
+        applyValue();
+    }
+}
 
-    if(!cmpf(_value,pinValue))
-    {
-        pinValue = _value;
-        valueChanged(pinValue);
+GPIO::Mode GPIO::mode() const
+{
+    return m_mode;
+}
+
+void GPIO::setMode(Mode mode)
+{
+    if (m_mode != mode) {
+        stopPwmThread();
+        m_mode = mode;
+        emit modeChanged(m_mode);
+        applyValue();
+    }
+}
+
+int GPIO::pwmFrequency() const
+{
+    return m_pwmFrequency;
+}
+
+void GPIO::setPwmFrequency(int frequency)
+{
+    if (frequency < 1)
+        frequency = 1;
+    if (m_pwmFrequency != frequency) {
+        m_pwmFrequency = frequency;
+        emit pwmFrequencyChanged(m_pwmFrequency);
+    }
+}
+
+bool GPIO::enabled() const
+{
+    return m_enabled;
+}
+
+void GPIO::setEnabled(bool enabled)
+{
+    if (m_enabled != enabled) {
+        m_enabled = enabled;
+        emit enabledChanged(m_enabled);
+        if (m_enabled && m_line >= 0) {
+            openLine();
+            applyValue();
+        } else {
+            stopPwmThread();
+            closeLine();
+        }
+    }
+}
+
+QVariantList GPIO::availableChips()
+{
+    QVariantList chips;
+    QDir devDir("/dev");
+    QStringList filters;
+    filters << "gpiochip*";
+    QStringList entries = devDir.entryList(filters, QDir::System, QDir::Name);
+
+    for (const QString &entry : entries) {
+        QString path = "/dev/" + entry;
+        struct gpiod_chip *chip = gpiod_chip_open(path.toUtf8().constData());
+        if (chip) {
+            QString label;
+            struct gpiod_chip_info *info = gpiod_chip_get_info(chip);
+            if (info) {
+                label = QString::fromUtf8(gpiod_chip_info_get_label(info));
+                gpiod_chip_info_free(info);
+            }
+            QVariantMap item;
+            item["value"] = path;
+            if (label.isEmpty())
+                item["text"] = entry;
+            else
+                item["text"] = entry + " (" + label + ")";
+            chips.append(item);
+            gpiod_chip_close(chip);
+        }
     }
 
-    if(pinNumber >= 0)
-    {
-        QFile io(IO_DEVICE);
-        if(io.open(QFile::WriteOnly | QIODevice::Text))
-        {
-            QString io_string = QString::number(pinNumber) + QString("=") + QString::number(pinValue) + "\n";
-            io.write(io_string.toLatin1());
-            io.flush();
-            io.close();
-        }
-        else
-        {
-            qDebug() << "Could not access pi-blaster";
-        }
-
-        qDebug() << "Pin: " << pinNumber << " is set to " << pinValue;
+    if (chips.isEmpty()) {
+        QVariantMap item;
+        item["value"] = "";
+        item["text"] = "(no GPIO chips found)";
+        chips.append(item);
     }
+
+    return chips;
+}
+
+QVariantList GPIO::availableLines(const QString &chipPath)
+{
+    QVariantList lines;
+
+    if (chipPath.isEmpty())
+        return lines;
+
+    struct gpiod_chip *chip = gpiod_chip_open(chipPath.toUtf8().constData());
+    if (!chip) {
+        qWarning() << "GPIO: Cannot open chip" << chipPath << "for line enumeration";
+        return lines;
+    }
+
+    size_t numLines = 0;
+    struct gpiod_chip_info *chipInfo = gpiod_chip_get_info(chip);
+    if (chipInfo) {
+        numLines = gpiod_chip_info_get_num_lines(chipInfo);
+        gpiod_chip_info_free(chipInfo);
+    }
+    for (size_t i = 0; i < numLines; ++i) {
+        struct gpiod_line_info *info = gpiod_chip_get_line_info(chip, i);
+        if (!info)
+            continue;
+
+        QString name = QString::fromUtf8(gpiod_line_info_get_name(info));
+        bool inUse = gpiod_line_info_is_used(info);
+
+        QVariantMap item;
+        item["value"] = static_cast<int>(i);
+        QString label = QString::number(i);
+        if (!name.isEmpty())
+            label += " — " + name;
+        if (inUse)
+            label += " [in use]";
+        item["text"] = label;
+        lines.append(item);
+
+        gpiod_line_info_free(info);
+    }
+
+    gpiod_chip_close(chip);
+    return lines;
+}
+
+void GPIO::openLine()
+{
+    closeLine();
+
+    if (m_chipPath.isEmpty() || m_line < 0)
+        return;
+
+    m_chip = gpiod_chip_open(m_chipPath.toUtf8().constData());
+    if (!m_chip) {
+        qWarning() << "GPIO: Cannot open chip" << m_chipPath;
+        return;
+    }
+
+    struct gpiod_line_settings *lineSettings = gpiod_line_settings_new();
+    gpiod_line_settings_set_direction(lineSettings, GPIOD_LINE_DIRECTION_OUTPUT);
+    gpiod_line_settings_set_output_value(lineSettings, GPIOD_LINE_VALUE_INACTIVE);
+
+    struct gpiod_line_config *lineConfig = gpiod_line_config_new();
+    unsigned int offset = static_cast<unsigned int>(m_line);
+    gpiod_line_config_add_line_settings(lineConfig, &offset, 1, lineSettings);
+
+    struct gpiod_request_config *reqConfig = gpiod_request_config_new();
+    gpiod_request_config_set_consumer(reqConfig, "qtbooth");
+
+    m_request = gpiod_chip_request_lines(m_chip, reqConfig, lineConfig);
+
+    gpiod_request_config_free(reqConfig);
+    gpiod_line_config_free(lineConfig);
+    gpiod_line_settings_free(lineSettings);
+
+    if (!m_request) {
+        qWarning() << "GPIO: Cannot request line" << m_line << "on" << m_chipPath;
+        gpiod_chip_close(m_chip);
+        m_chip = nullptr;
+        return;
+    }
+
+    qDebug() << "GPIO: Opened line" << m_line << "on" << m_chipPath;
+}
+
+void GPIO::closeLine()
+{
+    stopPwmThread();
+
+    if (m_request) {
+        gpiod_line_request_set_value(m_request, static_cast<unsigned int>(m_line), GPIOD_LINE_VALUE_INACTIVE);
+        gpiod_line_request_release(m_request);
+        m_request = nullptr;
+    }
+    if (m_chip) {
+        gpiod_chip_close(m_chip);
+        m_chip = nullptr;
+    }
+}
+
+void GPIO::applyValue()
+{
+    if (!m_enabled || !m_request)
+        return;
+
+    if (m_mode == Output) {
+        stopPwmThread();
+        enum gpiod_line_value val = (m_value >= 0.5f) ? GPIOD_LINE_VALUE_ACTIVE : GPIOD_LINE_VALUE_INACTIVE;
+        gpiod_line_request_set_value(m_request, static_cast<unsigned int>(m_line), val);
+        qDebug() << "GPIO: Line" << m_line << "set to" << (val == GPIOD_LINE_VALUE_ACTIVE ? "HIGH" : "LOW");
+    } else {
+        // PWM mode
+        m_pwmDuty.store(m_value, std::memory_order_relaxed);
+
+        if (m_value <= 0.0f) {
+            stopPwmThread();
+            gpiod_line_request_set_value(m_request, static_cast<unsigned int>(m_line), GPIOD_LINE_VALUE_INACTIVE);
+        } else if (m_value >= 1.0f) {
+            stopPwmThread();
+            gpiod_line_request_set_value(m_request, static_cast<unsigned int>(m_line), GPIOD_LINE_VALUE_ACTIVE);
+        } else {
+            if (!m_pwmRunning.load(std::memory_order_acquire)) {
+                startPwmThread();
+            }
+        }
+    }
+}
+
+void GPIO::startPwmThread()
+{
+    if (m_pwmRunning.load(std::memory_order_acquire))
+        return;
+
+    m_pwmRunning.store(true, std::memory_order_release);
+    m_pwmThread = std::thread(&GPIO::pwmWorker, this);
+    qDebug() << "GPIO: PWM thread started for line" << m_line << "at" << m_pwmFrequency << "Hz";
+}
+
+void GPIO::stopPwmThread()
+{
+    if (m_pwmRunning.load(std::memory_order_acquire)) {
+        m_pwmRunning.store(false, std::memory_order_release);
+        if (m_pwmThread.joinable())
+            m_pwmThread.join();
+    }
+}
+
+void GPIO::pwmWorker()
+{
+    const unsigned int lineOffset = static_cast<unsigned int>(m_line);
+
+    while (m_pwmRunning.load(std::memory_order_acquire)) {
+        float duty = m_pwmDuty.load(std::memory_order_relaxed);
+
+        // Clamp duty to valid PWM range (edge values handled in applyValue)
+        duty = std::clamp(duty, 0.001f, 0.999f);
+
+        // Calculate period in nanoseconds
+        long periodNs = 1000000000L / m_pwmFrequency;
+        long onTimeNs = static_cast<long>(periodNs * duty);
+        long offTimeNs = periodNs - onTimeNs;
+
+        // HIGH phase
+        if (m_request)
+            gpiod_line_request_set_value(m_request, lineOffset, GPIOD_LINE_VALUE_ACTIVE);
+
+        struct timespec onSleep;
+        onSleep.tv_sec = onTimeNs / 1000000000L;
+        onSleep.tv_nsec = onTimeNs % 1000000000L;
+        nanosleep(&onSleep, nullptr);
+
+        if (!m_pwmRunning.load(std::memory_order_acquire))
+            break;
+
+        // LOW phase
+        if (m_request)
+            gpiod_line_request_set_value(m_request, lineOffset, GPIOD_LINE_VALUE_INACTIVE);
+
+        struct timespec offSleep;
+        offSleep.tv_sec = offTimeNs / 1000000000L;
+        offSleep.tv_nsec = offTimeNs % 1000000000L;
+        nanosleep(&offSleep, nullptr);
+    }
+
+    // Ensure line is LOW when thread exits
+    if (m_request)
+        gpiod_line_request_set_value(m_request, lineOffset, GPIOD_LINE_VALUE_INACTIVE);
 }

--- a/src/gpio.cpp
+++ b/src/gpio.cpp
@@ -11,6 +11,7 @@
 #include <time.h>
 #include <pthread.h>
 #include <sched.h>
+#include <immintrin.h>
 
 Gpiod::Gpiod(QObject *parent)
     : QObject(parent)
@@ -401,29 +402,34 @@ void Gpiod::pwmWorker()
 void Gpiod::precisionSleep(long nanoseconds)
 {
     using namespace std::chrono;
-    const long MIN_SLEEP_NS = 500000; // 0.5ms threshold
+    const long BUSY_WAIT_THRESHOLD_NS = 50000; // Only busy-wait for < 50µs
     
     if (nanoseconds <= 0)
         return;
     
-    if (nanoseconds >= MIN_SLEEP_NS) {
-        // For longer durations, use nanosleep then busy-wait for remainder
-        long sleepNs = nanoseconds - (MIN_SLEEP_NS / 2); // Leave margin for overhead
+    if (nanoseconds > BUSY_WAIT_THRESHOLD_NS) {
+        // For longer durations, use clock_nanosleep (more predictable than nanosleep)
+        // Leave a small margin for busy-wait to catch up any undersleep
+        long sleepNs = nanoseconds - BUSY_WAIT_THRESHOLD_NS;
         struct timespec ts;
         ts.tv_sec = sleepNs / 1000000000L;
         ts.tv_nsec = sleepNs % 1000000000L;
-        nanosleep(&ts, nullptr);
         
-        // Busy-wait for remaining time for better precision
-        auto deadline = high_resolution_clock::now() + std::chrono::nanoseconds(nanoseconds);
-        while (high_resolution_clock::now() < deadline) {
-            // Spin-wait
-        }
-    } else {
-        // For short durations, busy-wait for maximum precision
-        auto deadline = high_resolution_clock::now() + std::chrono::nanoseconds(nanoseconds);
-        while (high_resolution_clock::now() < deadline) {
-            // Spin-wait
-        }
+        // Use CLOCK_MONOTONIC for predictability (not affected by NTP adjustments)
+        clock_nanosleep(CLOCK_MONOTONIC, 0, &ts, nullptr);
+    }
+    
+    // Busy-wait for final precision, but with CPU pause instructions
+    // This is much more efficient than tight spin-loop
+    auto deadline = high_resolution_clock::now() + std::chrono::nanoseconds(nanoseconds);
+    while (high_resolution_clock::now() < deadline) {
+        // Pause instruction reduces CPU power usage and helps hyperthreading
+        #if defined(__x86_64__) || defined(__i386__)
+            __builtin_ia32_pause();  // x86/x64: ~40 cycles per pause
+        #elif defined(__arm__) || defined(__aarch64__)
+            __asm__ __volatile__("yield");  // ARM: yield to other threads
+        #else
+            __asm__ __volatile__("" ::: "memory");  // Prevent loop optimization
+        #endif
     }
 }

--- a/src/gpio.cpp
+++ b/src/gpio.cpp
@@ -1,10 +1,13 @@
 #include "gpio.h"
 #include <QDebug>
 #include <QDir>
+#include <QFileInfo>
 #include <QVariantMap>
 #include <cmath>
 #include <algorithm>
 #include <chrono>
+#include <cerrno>
+#include <cstring>
 
 GPIO::GPIO(QObject *parent)
     : QObject(parent)
@@ -122,28 +125,74 @@ QVariantList GPIO::availableChips()
     filters << "gpiochip*";
     QStringList entries = devDir.entryList(filters, QDir::System, QDir::Name);
 
+    qDebug() << "GPIO: Scanning /dev for gpiochip* entries, found" << entries.size() << "candidates";
+    if (entries.isEmpty())
+        qWarning() << "GPIO: No gpiochip devices found in /dev";
+
     for (const QString &entry : entries) {
         QString path = "/dev/" + entry;
-        struct gpiod_chip *chip = gpiod_chip_open(path.toUtf8().constData());
-        if (chip) {
-            QString label;
-            struct gpiod_chip_info *info = gpiod_chip_get_info(chip);
-            if (info) {
-                label = QString::fromUtf8(gpiod_chip_info_get_label(info));
-                gpiod_chip_info_free(info);
-            }
-            QVariantMap item;
-            item["value"] = path;
-            if (label.isEmpty())
-                item["text"] = entry;
-            else
-                item["text"] = entry + " (" + label + ")";
-            chips.append(item);
-            gpiod_chip_close(chip);
+        QFileInfo fileInfo(path);
+
+        qDebug() << "GPIO: Candidate" << path
+                 << "exists=" << fileInfo.exists()
+                 << "readable=" << fileInfo.isReadable()
+                 << "writable=" << fileInfo.isWritable();
+
+        if (!fileInfo.isReadable() || !fileInfo.isWritable()) {
+            qWarning() << "GPIO: Permission warning for" << path
+                       << "(readable=" << fileInfo.isReadable()
+                       << ", writable=" << fileInfo.isWritable() << ")";
         }
+
+        errno = 0;
+        struct gpiod_chip *chip = gpiod_chip_open(path.toUtf8().constData());
+        if (!chip) {
+            qWarning() << "GPIO: Failed to open chip" << path
+                       << "errno=" << errno
+                       << "(" << QString::fromLocal8Bit(std::strerror(errno)) << ")";
+            continue;
+        }
+
+        qDebug() << "GPIO: Successfully opened chip interface" << path;
+
+        QString label;
+        errno = 0;
+        struct gpiod_chip_info *info = gpiod_chip_get_info(chip);
+        if (info) {
+            const char *chipName = gpiod_chip_info_get_name(info);
+            const char *chipLabel = gpiod_chip_info_get_label(info);
+            const size_t numLines = gpiod_chip_info_get_num_lines(info);
+
+            if (chipLabel)
+                label = QString::fromUtf8(chipLabel);
+
+            qDebug() << "GPIO: Chip info read ok for" << path
+                     << "name=" << (chipName ? chipName : "")
+                     << "label=" << (chipLabel ? chipLabel : "")
+                     << "lines=" << static_cast<qulonglong>(numLines);
+
+            gpiod_chip_info_free(info);
+        } else {
+            qWarning() << "GPIO: Failed to read chip info for" << path
+                       << "errno=" << errno
+                       << "(" << QString::fromLocal8Bit(std::strerror(errno)) << ")";
+        }
+
+        QVariantMap item;
+        item["value"] = path;
+        if (label.isEmpty())
+            item["text"] = entry;
+        else
+            item["text"] = entry + " (" + label + ")";
+        chips.append(item);
+
+        gpiod_chip_close(chip);
     }
 
     if (chips.isEmpty()) {
+        if (!entries.isEmpty()) {
+            qWarning() << "GPIO: gpiochip devices were found in /dev but none could be opened/read. Check permissions and kernel GPIO support.";
+        }
         QVariantMap item;
         item["value"] = "";
         item["text"] = "(no GPIO chips found)";

--- a/src/gpio.cpp
+++ b/src/gpio.cpp
@@ -339,6 +339,7 @@ void Gpiod::startPwmThread()
     m_pwmThread = std::thread(&Gpiod::pwmWorker, this);
     const int frequency = m_pwmFrequency.load(std::memory_order_relaxed);
     qDebug() << "GPIO: PWM thread started for line" << m_line << "at" << frequency << "Hz";
+}
 
 void Gpiod::stopPwmThread()
 {

--- a/src/gpio.cpp
+++ b/src/gpio.cpp
@@ -85,16 +85,16 @@ void Gpiod::setMode(Mode mode)
 
 int Gpiod::pwmFrequency() const
 {
-    return m_pwmFrequency;
+    return m_pwmFrequency.load();
 }
 
 void Gpiod::setPwmFrequency(int frequency)
 {
     if (frequency < 1)
         frequency = 1;
-    if (m_pwmFrequency != frequency) {
-        m_pwmFrequency = frequency;
-        emit pwmFrequencyChanged(m_pwmFrequency);
+    if (m_pwmFrequency.load() != frequency) {
+        m_pwmFrequency.store(frequency);
+        emit pwmFrequencyChanged(frequency);
     }
 }
 

--- a/src/gpio.cpp
+++ b/src/gpio.cpp
@@ -238,7 +238,8 @@ QVariantList Gpiod::availableLines(const QString &chipPath)
         if (!info)
             continue;
 
-        QString name = QString::fromUtf8(gpiod_line_info_get_name(info));
+        const char *rawName = gpiod_line_info_get_name(info);
+        QString name = rawName ? QString::fromUtf8(rawName) : QString();
         bool inUse = gpiod_line_info_is_used(info);
 
         QVariantMap item;

--- a/src/gpio.cpp
+++ b/src/gpio.cpp
@@ -410,6 +410,7 @@ void Gpiod::precisionSleep(long nanoseconds)
 {
     using namespace std::chrono;
     const long BUSY_WAIT_THRESHOLD_NS = 50000; // Only busy-wait for < 50µs
+    long busyWaitNs = nanoseconds;
     
     if (nanoseconds <= 0)
         return;
@@ -418,6 +419,7 @@ void Gpiod::precisionSleep(long nanoseconds)
         // For longer durations, use clock_nanosleep (more predictable than nanosleep)
         // Leave a small margin for busy-wait to catch up any undersleep
         long sleepNs = nanoseconds - BUSY_WAIT_THRESHOLD_NS;
+        busyWaitNs = BUSY_WAIT_THRESHOLD_NS;
         struct timespec ts;
         ts.tv_sec = sleepNs / 1000000000L;
         ts.tv_nsec = sleepNs % 1000000000L;
@@ -428,8 +430,8 @@ void Gpiod::precisionSleep(long nanoseconds)
     
     // Busy-wait for final precision, but with CPU pause instructions
     // This is much more efficient than tight spin-loop
-    auto deadline = high_resolution_clock::now() + std::chrono::nanoseconds(nanoseconds);
-    while (high_resolution_clock::now() < deadline) {
+    auto deadline = steady_clock::now() + std::chrono::nanoseconds(busyWaitNs);
+    while (steady_clock::now() < deadline) {
         // Pause instruction reduces CPU power usage and helps hyperthreading
         #if defined(__x86_64__) || defined(__i386__)
             __builtin_ia32_pause();  // x86/x64: ~40 cycles per pause

--- a/src/gpio.cpp
+++ b/src/gpio.cpp
@@ -11,7 +11,9 @@
 #include <time.h>
 #include <pthread.h>
 #include <sched.h>
+#if defined(__x86_64__) || defined(__i386__)
 #include <immintrin.h>
+#endif
 
 Gpiod::Gpiod(QObject *parent)
     : QObject(parent)

--- a/src/gpio.cpp
+++ b/src/gpio.cpp
@@ -35,8 +35,10 @@ void Gpiod::setChipPath(const QString &chipPath)
         closeLine();
         m_chipPath = chipPath;
         emit chipPathChanged(m_chipPath);
-        if (m_enabled && m_line >= 0)
+        if (m_enabled && m_line >= 0) {
             openLine();
+            applyValue();
+        }
     }
 }
 

--- a/src/gpio.cpp
+++ b/src/gpio.cpp
@@ -92,6 +92,8 @@ void Gpiod::setPwmFrequency(int frequency)
 {
     if (frequency < 1)
         frequency = 1;
+    if (frequency > 10000)
+        frequency = 10000;
     if (m_pwmFrequency.load() != frequency) {
         m_pwmFrequency.store(frequency);
         emit pwmFrequencyChanged(frequency);

--- a/src/gpio.cpp
+++ b/src/gpio.cpp
@@ -55,8 +55,10 @@ void Gpiod::setLine(int line)
         closeLine();
         m_line = line;
         emit lineChanged(m_line);
-        if (m_enabled && m_line >= 0)
+        if (m_enabled && m_line >= 0) {
             openLine();
+            applyValue();
+        }
     }
 }
 

--- a/src/gpio.cpp
+++ b/src/gpio.cpp
@@ -337,8 +337,8 @@ void Gpiod::startPwmThread()
 
     m_pwmRunning.store(true, std::memory_order_release);
     m_pwmThread = std::thread(&Gpiod::pwmWorker, this);
-    qDebug() << "GPIO: PWM thread started for line" << m_line << "at" << m_pwmFrequency << "Hz";
-}
+    const int frequency = m_pwmFrequency.load(std::memory_order_relaxed);
+    qDebug() << "GPIO: PWM thread started for line" << m_line << "at" << frequency << "Hz";
 
 void Gpiod::stopPwmThread()
 {

--- a/src/gpio.cpp
+++ b/src/gpio.cpp
@@ -9,6 +9,8 @@
 #include <cerrno>
 #include <cstring>
 #include <time.h>
+#include <pthread.h>
+#include <sched.h>
 
 Gpiod::Gpiod(QObject *parent)
     : QObject(parent)
@@ -339,6 +341,13 @@ void Gpiod::startPwmThread()
 
     m_pwmRunning.store(true, std::memory_order_release);
     m_pwmThread = std::thread(&Gpiod::pwmWorker, this);
+    
+    // Set high priority for PWM thread to reduce jitter
+    int policy = SCHED_FIFO;
+    struct sched_param param;
+    param.sched_priority = sched_get_priority_max(policy) - 1;
+    pthread_setschedparam(m_pwmThread.native_handle(), policy, &param);
+    
     const int frequency = m_pwmFrequency.load(std::memory_order_relaxed);
     qDebug() << "GPIO: PWM thread started for line" << m_line << "at" << frequency << "Hz";
 }
@@ -354,43 +363,67 @@ void Gpiod::stopPwmThread()
 
 void Gpiod::pwmWorker()
 {
+    using namespace std::chrono;
     const unsigned int lineOffset = static_cast<unsigned int>(m_line);
 
     while (m_pwmRunning.load(std::memory_order_acquire)) {
+        // Cache frequency and duty once per cycle to reduce jitter
+        const int frequency = m_pwmFrequency.load(std::memory_order_relaxed);
         float duty = m_pwmDuty.load(std::memory_order_relaxed);
-
-        // Clamp duty to valid PWM range (edge values handled in applyValue)
         duty = std::clamp(duty, 0.001f, 0.999f);
 
-        // Calculate period in nanoseconds
-        const int frequency = m_pwmFrequency.load(std::memory_order_relaxed);
-        long periodNs = 1000000000L / frequency;
-        long onTimeNs = static_cast<long>(periodNs * duty);
-        long offTimeNs = periodNs - onTimeNs;
+        // Pre-calculate timing for the entire period
+        const long periodNs = 1000000000L / frequency;
+        const long onTimeNs = static_cast<long>(periodNs * duty);
+        const long offTimeNs = periodNs - onTimeNs;
 
-        // HIGH phase
+        // HIGH phase with high-precision timing
         if (m_request)
             gpiod_line_request_set_value(m_request, lineOffset, GPIOD_LINE_VALUE_ACTIVE);
 
-        struct timespec onSleep;
-        onSleep.tv_sec = onTimeNs / 1000000000L;
-        onSleep.tv_nsec = onTimeNs % 1000000000L;
-        nanosleep(&onSleep, nullptr);
+        precisionSleep(onTimeNs);
 
         if (!m_pwmRunning.load(std::memory_order_acquire))
             break;
 
-        // LOW phase
+        // LOW phase with high-precision timing
         if (m_request)
             gpiod_line_request_set_value(m_request, lineOffset, GPIOD_LINE_VALUE_INACTIVE);
 
-        struct timespec offSleep;
-        offSleep.tv_sec = offTimeNs / 1000000000L;
-        offSleep.tv_nsec = offTimeNs % 1000000000L;
-        nanosleep(&offSleep, nullptr);
+        precisionSleep(offTimeNs);
     }
 
     // Ensure line is LOW when thread exits
     if (m_request)
         gpiod_line_request_set_value(m_request, lineOffset, GPIOD_LINE_VALUE_INACTIVE);
+}
+
+void Gpiod::precisionSleep(long nanoseconds)
+{
+    using namespace std::chrono;
+    const long MIN_SLEEP_NS = 500000; // 0.5ms threshold
+    
+    if (nanoseconds <= 0)
+        return;
+    
+    if (nanoseconds >= MIN_SLEEP_NS) {
+        // For longer durations, use nanosleep then busy-wait for remainder
+        long sleepNs = nanoseconds - (MIN_SLEEP_NS / 2); // Leave margin for overhead
+        struct timespec ts;
+        ts.tv_sec = sleepNs / 1000000000L;
+        ts.tv_nsec = sleepNs % 1000000000L;
+        nanosleep(&ts, nullptr);
+        
+        // Busy-wait for remaining time for better precision
+        auto deadline = high_resolution_clock::now() + std::chrono::nanoseconds(nanoseconds);
+        while (high_resolution_clock::now() < deadline) {
+            // Spin-wait
+        }
+    } else {
+        // For short durations, busy-wait for maximum precision
+        auto deadline = high_resolution_clock::now() + std::chrono::nanoseconds(nanoseconds);
+        while (high_resolution_clock::now() < deadline) {
+            // Spin-wait
+        }
+    }
 }

--- a/src/gpio.h
+++ b/src/gpio.h
@@ -2,27 +2,82 @@
 #define GPIO_H
 
 #include <QObject>
+#include <QVariantList>
+#include <QString>
+#include <atomic>
+#include <thread>
+#include <gpiod.h>
 
 class GPIO : public QObject
 {
     Q_OBJECT
-    Q_PROPERTY(int pin READ pin WRITE setPin NOTIFY pinChanged)
+    Q_PROPERTY(QString chipPath READ chipPath WRITE setChipPath NOTIFY chipPathChanged)
+    Q_PROPERTY(int line READ line WRITE setLine NOTIFY lineChanged)
     Q_PROPERTY(float value READ value WRITE setValue NOTIFY valueChanged)
+    Q_PROPERTY(Mode mode READ mode WRITE setMode NOTIFY modeChanged)
+    Q_PROPERTY(int pwmFrequency READ pwmFrequency WRITE setPwmFrequency NOTIFY pwmFrequencyChanged)
+    Q_PROPERTY(bool enabled READ enabled WRITE setEnabled NOTIFY enabledChanged)
+
 public:
+    enum Mode {
+        Output,
+        PWM
+    };
+    Q_ENUM(Mode)
+
     explicit GPIO(QObject *parent = nullptr);
     ~GPIO();
-    int pin() const;
-    void setPin(int pin);
+
+    QString chipPath() const;
+    void setChipPath(const QString &chipPath);
+
+    int line() const;
+    void setLine(int line);
+
     float value() const;
     void setValue(float value);
-signals:
-    void pinChanged(int);
-    void valueChanged(float);
-protected:
-    int pinNumber = -1; //pin is not set
-    float pinValue = 0.0;
-signals:
 
+    Mode mode() const;
+    void setMode(Mode mode);
+
+    int pwmFrequency() const;
+    void setPwmFrequency(int frequency);
+
+    bool enabled() const;
+    void setEnabled(bool enabled);
+
+    Q_INVOKABLE static QVariantList availableChips();
+    Q_INVOKABLE static QVariantList availableLines(const QString &chipPath);
+
+signals:
+    void chipPathChanged(const QString &chipPath);
+    void lineChanged(int line);
+    void valueChanged(float value);
+    void modeChanged(Mode mode);
+    void pwmFrequencyChanged(int frequency);
+    void enabledChanged(bool enabled);
+
+private:
+    void openLine();
+    void closeLine();
+    void applyValue();
+    void startPwmThread();
+    void stopPwmThread();
+    void pwmWorker();
+
+    QString m_chipPath = "/dev/gpiochip0";
+    int m_line = -1;
+    float m_value = 0.0f;
+    Mode m_mode = Output;
+    int m_pwmFrequency = 1000;
+    bool m_enabled = false;
+
+    struct gpiod_chip *m_chip = nullptr;
+    struct gpiod_line_request *m_request = nullptr;
+
+    std::thread m_pwmThread;
+    std::atomic<float> m_pwmDuty{0.0f};
+    std::atomic<bool> m_pwmRunning{false};
 };
 
 #endif // GPIO_H

--- a/src/gpio.h
+++ b/src/gpio.h
@@ -1,5 +1,5 @@
-#ifndef GPIO_H
-#define GPIO_H
+#ifndef GPIOD_H
+#define GPIOD_H
 
 #include <QObject>
 #include <QVariantList>
@@ -8,7 +8,7 @@
 #include <thread>
 #include <gpiod.h>
 
-class GPIO : public QObject
+class Gpiod : public QObject
 {
     Q_OBJECT
     Q_PROPERTY(QString chipPath READ chipPath WRITE setChipPath NOTIFY chipPathChanged)
@@ -25,8 +25,8 @@ public:
     };
     Q_ENUM(Mode)
 
-    explicit GPIO(QObject *parent = nullptr);
-    ~GPIO();
+    explicit Gpiod(QObject *parent = nullptr);
+    ~Gpiod();
 
     QString chipPath() const;
     void setChipPath(const QString &chipPath);
@@ -80,4 +80,4 @@ private:
     std::atomic<bool> m_pwmRunning{false};
 };
 
-#endif // GPIO_H
+#endif // GPIOD_H

--- a/src/gpio.h
+++ b/src/gpio.h
@@ -6,6 +6,7 @@
 #include <QString>
 #include <atomic>
 #include <thread>
+#include <pthread.h>
 #include <gpiod.h>
 
 class Gpiod : public QObject
@@ -64,6 +65,7 @@ private:
     void startPwmThread();
     void stopPwmThread();
     void pwmWorker();
+    void precisionSleep(long nanoseconds);
 
     QString m_chipPath = "/dev/gpiochip0";
     int m_line = -1;

--- a/src/gpio.h
+++ b/src/gpio.h
@@ -69,7 +69,7 @@ private:
     int m_line = -1;
     float m_value = 0.0f;
     Mode m_mode = Output;
-    int m_pwmFrequency = 1000;
+    std::atomic<int> m_pwmFrequency{1000};
     bool m_enabled = false;
 
     struct gpiod_chip *m_chip = nullptr;

--- a/src/gpio.h
+++ b/src/gpio.h
@@ -46,8 +46,8 @@ public:
     bool enabled() const;
     void setEnabled(bool enabled);
 
-    Q_INVOKABLE static QVariantList availableChips();
-    Q_INVOKABLE static QVariantList availableLines(const QString &chipPath);
+    Q_INVOKABLE QVariantList availableChips();
+    Q_INVOKABLE QVariantList availableLines(const QString &chipPath);
 
 signals:
     void chipPathChanged(const QString &chipPath);

--- a/src/gpio.h
+++ b/src/gpio.h
@@ -1,5 +1,5 @@
-#ifndef GPIOD_H
-#define GPIOD_H
+#ifndef QTBOOTH_GPIOD_WRAPPER_H
+#define QTBOOTH_GPIOD_WRAPPER_H
 
 #include <QObject>
 #include <QVariantList>

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -121,7 +121,7 @@ int main(int argc, char *argv[])
     qmlRegisterUncreatableType<CollageIconModel>("CollageModel", 1, 0, "CollageIconModel", "CollageIconModel can only be created via CollageModeFactory");
     qmlRegisterUncreatableType<CollageImageModel>("CollageModel", 1, 0, "CollageImageModel", "CollageImageModel can only be created via CollageModeFactory");
 
-    qmlRegisterType<GPIO>("Gpio", 1, 0, "GPIO");
+    qmlRegisterType<Gpiod>("Gpio", 1, 0, "Gpiod");
 
     qmlRegisterType<FileIO>("FileIO", 1, 0, "FileIO");
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -121,7 +121,7 @@ int main(int argc, char *argv[])
     qmlRegisterUncreatableType<CollageIconModel>("CollageModel", 1, 0, "CollageIconModel", "CollageIconModel can only be created via CollageModeFactory");
     qmlRegisterUncreatableType<CollageImageModel>("CollageModel", 1, 0, "CollageImageModel", "CollageImageModel can only be created via CollageModeFactory");
 
-    qmlRegisterType<GPIO>("GPIO", 1, 0, "GPIO");
+    qmlRegisterType<GPIO>("Gpio", 1, 0, "GPIO");
 
     qmlRegisterType<FileIO>("FileIO", 1, 0, "FileIO");
 

--- a/udev/99-gpio-orangepi3b.rules
+++ b/udev/99-gpio-orangepi3b.rules
@@ -1,0 +1,5 @@
+# udev rules for GPIO access on Orange Pi 3B (RK3566)
+# Grants read/write access to /dev/gpiochip* for members of the "gpio" group.
+# Install to /etc/udev/rules.d/99-gpio-photobooth.rules
+
+SUBSYSTEM=="gpio", KERNEL=="gpiochip*", GROUP="gpio", MODE="0660"

--- a/udev/99-gpio-raspberrypi.rules
+++ b/udev/99-gpio-raspberrypi.rules
@@ -1,0 +1,5 @@
+# udev rules for GPIO access on Raspberry Pi (all models)
+# Grants read/write access to /dev/gpiochip* for members of the "gpio" group.
+# Install to /etc/udev/rules.d/99-gpio-photobooth.rules
+
+SUBSYSTEM=="gpio", KERNEL=="gpiochip*", GROUP="gpio", MODE="0660"

--- a/udev/install-gpio-rules.sh
+++ b/udev/install-gpio-rules.sh
@@ -1,0 +1,89 @@
+#!/bin/bash
+# install-gpio-rules.sh — Install udev rules for GPIO access
+# Usage: sudo ./install-gpio-rules.sh
+#
+# Detects the board type from /proc/device-tree/model and installs the
+# appropriate udev rules file to /etc/udev/rules.d/.
+# Creates a "gpio" group if it doesn't exist and adds the current user to it.
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+RULES_DIR="/etc/udev/rules.d"
+TARGET_RULE="99-gpio-photobooth.rules"
+
+if [ "$EUID" -ne 0 ]; then
+    echo "Error: This script must be run as root (use sudo)."
+    exit 1
+fi
+
+# Detect board type
+BOARD=""
+if [ -f /proc/device-tree/model ]; then
+    MODEL=$(tr -d '\0' < /proc/device-tree/model)
+    echo "Detected board: ${MODEL}"
+
+    if echo "${MODEL}" | grep -qi "raspberry pi"; then
+        BOARD="raspberrypi"
+    elif echo "${MODEL}" | grep -qi "orange pi"; then
+        BOARD="orangepi3b"
+    elif echo "${MODEL}" | grep -qi "rk3566\|rock\|radxa\|quartz64\|pine64"; then
+        BOARD="orangepi3b"  # Use RK3566-compatible rules
+    fi
+fi
+
+if [ -z "${BOARD}" ]; then
+    echo ""
+    echo "Could not auto-detect board type."
+    echo "Please select your board:"
+    echo "  1) Raspberry Pi (any model)"
+    echo "  2) Orange Pi 3B / RK3566-based SBC"
+    echo ""
+    read -rp "Selection [1-2]: " choice
+    case "$choice" in
+        1) BOARD="raspberrypi" ;;
+        2) BOARD="orangepi3b" ;;
+        *) echo "Invalid selection. Aborting."; exit 1 ;;
+    esac
+fi
+
+SOURCE_RULE="${SCRIPT_DIR}/99-gpio-${BOARD}.rules"
+
+if [ ! -f "${SOURCE_RULE}" ]; then
+    echo "Error: Rules file not found: ${SOURCE_RULE}"
+    exit 1
+fi
+
+echo "Installing ${SOURCE_RULE} → ${RULES_DIR}/${TARGET_RULE}"
+cp "${SOURCE_RULE}" "${RULES_DIR}/${TARGET_RULE}"
+chmod 644 "${RULES_DIR}/${TARGET_RULE}"
+
+# Create gpio group if it doesn't exist
+if ! getent group gpio > /dev/null 2>&1; then
+    echo "Creating 'gpio' group..."
+    groupadd gpio
+fi
+
+# Add the invoking user to the gpio group (handle sudo)
+REAL_USER="${SUDO_USER:-${USER}}"
+if [ -n "${REAL_USER}" ] && [ "${REAL_USER}" != "root" ]; then
+    if ! id -nG "${REAL_USER}" | grep -qw gpio; then
+        echo "Adding user '${REAL_USER}' to 'gpio' group..."
+        usermod -aG gpio "${REAL_USER}"
+    else
+        echo "User '${REAL_USER}' is already in 'gpio' group."
+    fi
+fi
+
+# Reload udev rules
+echo "Reloading udev rules..."
+udevadm control --reload-rules
+udevadm trigger
+
+echo ""
+echo "Done! GPIO udev rules installed for ${BOARD}."
+echo ""
+echo "IMPORTANT: You must log out and log back in (or reboot) for the"
+echo "group membership change to take effect."
+echo ""
+echo "After reboot, verify with:  ls -la /dev/gpiochip*"

--- a/udev/install-gpio-rules.sh
+++ b/udev/install-gpio-rules.sh
@@ -27,7 +27,7 @@ if [ -f /proc/device-tree/model ]; then
         BOARD="raspberrypi"
     elif echo "${MODEL}" | grep -qi "orange pi"; then
         BOARD="orangepi3b"
-    elif echo "${MODEL}" | grep -qi "rk3566\|rock\|radxa\|quartz64\|pine64"; then
+    elif echo "${MODEL}" | grep -Eqi "rk3566|rock|radxa|quartz64|pine64"; then
         BOARD="orangepi3b"  # Use RK3566-compatible rules
     fi
 fi


### PR DESCRIPTION
- Updated README.md to reflect GPIO support on any ARM SBC using libgpiod.
- Added GPIO configuration section with details on board presets and wiring.
- Introduced GPIO settings in the application, allowing users to enable GPIO and configure pins.
- Implemented GPIO handling in C++ with a new GPIO class, supporting PWM and line management.
- Added udev rules for Raspberry Pi and Orange Pi 3B to manage GPIO access.
- Created an installation script for setting up udev rules and permissions.
- Updated QML files to integrate GPIO settings into the UI, including enabling/disabling GPIO and configuring lines.
- Enhanced snapshot functionality to utilize GPIO for LED control.
- Add wake up signal for waking up a gphoto camera. Connected to the focus trigger.